### PR TITLE
Improve Discord crafting notifications and automate core pin updates

### DIFF
--- a/.github/scripts/tests/test_update_core_pin.py
+++ b/.github/scripts/tests/test_update_core_pin.py
@@ -1,0 +1,96 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "update_core_pin.py"
+BOT_NAME = "KLANKER | kuba6000"
+BOT_EMAIL = "agent@kuba6000.pl"
+
+
+class UpdateCorePinTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.repository = Path(self.temporary_directory.name) / "repository"
+        self.repository.mkdir()
+
+        self.git("init")
+        self.git("config", "user.name", "Test Setup")
+        self.git("config", "user.email", "setup@example.invalid")
+        self.git("config", "commit.gpgsign", "false")
+
+        (self.repository / "README.md").write_text("adapter\n", encoding="utf-8")
+        self.git("add", "README.md")
+        self.git("commit", "-m", "Create adapter branch")
+        self.old_core_sha = self.git("rev-parse", "HEAD").stdout.strip()
+
+        (self.repository / "core-change.txt").write_text("new core\n", encoding="utf-8")
+        self.git("add", "core-change.txt")
+        self.git("commit", "-m", "Change core")
+        self.new_core_sha = self.git("rev-parse", "HEAD").stdout.strip()
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def git(self, *arguments):
+        return subprocess.run(
+            ["git", "-C", str(self.repository), *arguments],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def pin_core(self, core_sha):
+        self.git("update-index", "--add", "--cacheinfo", f"160000,{core_sha},core")
+        self.git("commit", "-m", "Pin core")
+        (self.repository / "core").mkdir()
+        return self.git("rev-parse", "HEAD").stdout.strip()
+
+    def run_updater(self, core_sha):
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repository",
+                str(self.repository),
+                "--core-sha",
+                core_sha,
+                "--author-name",
+                BOT_NAME,
+                "--author-email",
+                BOT_EMAIL,
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_updates_only_core_gitlink_with_requested_author(self):
+        previous_head = self.pin_core(self.old_core_sha)
+
+        result = self.run_updater(self.new_core_sha)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertNotEqual(previous_head, self.git("rev-parse", "HEAD").stdout.strip())
+        self.assertEqual(self.new_core_sha, self.git("rev-parse", "HEAD:core").stdout.strip())
+        self.assertEqual("core", self.git("diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD").stdout.strip())
+        self.assertEqual(
+            [BOT_NAME, BOT_EMAIL, BOT_NAME, BOT_EMAIL],
+            self.git("log", "-1", "--format=%an%x00%ae%x00%cn%x00%ce").stdout.strip().split("\0"),
+        )
+        self.assertEqual("", self.git("status", "--porcelain").stdout)
+
+    def test_current_pin_does_not_create_a_commit(self):
+        previous_head = self.pin_core(self.new_core_sha)
+
+        result = self.run_updater(self.new_core_sha)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(previous_head, self.git("rev-parse", "HEAD").stdout.strip())
+        self.assertEqual("", self.git("status", "--porcelain").stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/update_core_pin.py
+++ b/.github/scripts/update_core_pin.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+class UpdateError(RuntimeError):
+    pass
+
+
+def git(repository, *arguments):
+    result = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip()
+        raise UpdateError(f"git {' '.join(arguments)} failed: {details}")
+    return result.stdout.strip()
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Commit an updated core submodule pin")
+    parser.add_argument("--repository", type=Path, default=Path.cwd())
+    parser.add_argument("--core-sha", required=True)
+    parser.add_argument("--author-name", required=True)
+    parser.add_argument("--author-email", required=True)
+    return parser.parse_args()
+
+
+def update_core_pin(repository, core_sha, author_name, author_email):
+    repository = repository.resolve()
+    core_sha = core_sha.lower()
+
+    if not re.fullmatch(r"[0-9a-f]{40}", core_sha):
+        raise UpdateError("core SHA must be a full 40-character SHA-1")
+
+    git(repository, "rev-parse", "--show-toplevel")
+    git(repository, "cat-file", "-e", f"{core_sha}^{{commit}}")
+
+    status = git(repository, "status", "--porcelain", "--untracked-files=all")
+    if status:
+        raise UpdateError("target worktree must be clean before updating the core pin")
+
+    index_entry = git(repository, "ls-files", "--stage", "--", "core")
+    match = re.fullmatch(r"(\d{6}) ([0-9a-f]{40}) 0\tcore", index_entry)
+    if match is None or match.group(1) != "160000":
+        raise UpdateError("core must be a tracked gitlink")
+
+    previous_sha = match.group(2)
+    if previous_sha == core_sha:
+        print(f"core is already pinned to {core_sha}")
+        return False
+
+    git(repository, "update-index", "--cacheinfo", f"160000,{core_sha},core")
+    staged_paths = git(repository, "diff", "--cached", "--name-only").splitlines()
+    if staged_paths != ["core"]:
+        raise UpdateError("updating the pin must stage exactly the core gitlink")
+
+    git(
+        repository,
+        "-c",
+        f"user.name={author_name}",
+        "-c",
+        f"user.email={author_email}",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-m",
+        f"Update core pin to {core_sha[:12]}",
+    )
+    print(f"updated core pin from {previous_sha} to {core_sha}")
+    return True
+
+
+def main():
+    arguments = parse_arguments()
+    try:
+        update_core_pin(
+            arguments.repository,
+            arguments.core_sha,
+            arguments.author_name,
+            arguments.author_email,
+        )
+    except UpdateError as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,12 +8,18 @@ on:
     branches: [ core ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout core
         uses: actions/checkout@v4
+
+      - name: Test core pin updater
+        run: python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py' -v
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/test-scala-presence.yml
+++ b/.github/workflows/test-scala-presence.yml
@@ -7,6 +7,9 @@ on:
     branches: [ core ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-scala-presence:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-core-pins.yml
+++ b/.github/workflows/update-core-pins.yml
@@ -1,0 +1,122 @@
+name: Update core pins
+
+on:
+  workflow_run:
+    workflows: [ Build and test core ]
+    types: [ completed ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-core-pins
+  cancel-in-progress: false
+
+jobs:
+  update-core-pins:
+    if: >-
+      github.repository == 'kuba6000/AE2-Web-Integration' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'core'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [ 1.7.10, 1.12.2, 1.20.1, 1.21.1 ]
+    env:
+      BOT_EMAIL: agent@kuba6000.pl
+      BOT_LOGIN: kuba6000-agent
+      BOT_NAME: "KLANKER | kuba6000"
+      CORE_SHA: ${{ github.event.workflow_run.head_sha }}
+      TARGET_BRANCH: ${{ matrix.branch }}
+
+    steps:
+      - name: Checkout trusted core automation
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: core
+          submodules: false
+
+      - name: Check whether the pin needs updating
+        id: prepare
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin \
+            "+refs/heads/core:refs/remotes/origin/core" \
+            "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+
+          latest_core_sha="$(git rev-parse refs/remotes/origin/core)"
+          if [[ "${CORE_SHA}" != "${latest_core_sha}" ]]; then
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            echo "Skipping obsolete successful core build ${CORE_SHA}; latest core is ${latest_core_sha}."
+            exit 0
+          fi
+
+          read -r mode object_type current_pin path \
+            <<< "$(git ls-tree "refs/remotes/origin/${TARGET_BRANCH}" core)"
+          if [[ "${mode}" != "160000" || "${object_type}" != "commit" || "${path}" != "core" ]]; then
+            echo "Branch ${TARGET_BRANCH} does not contain core as a gitlink." >&2
+            exit 1
+          fi
+
+          if [[ "${current_pin}" == "${CORE_SHA}" ]]; then
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            echo "${TARGET_BRANCH} already points to core ${CORE_SHA}."
+            exit 0
+          fi
+
+          echo "skip=false" >> "${GITHUB_OUTPUT}"
+          echo "Updating ${TARGET_BRANCH} from core ${current_pin} to ${CORE_SHA}."
+
+      - name: Verify bot token identity
+        if: steps.prepare.outputs.skip == 'false'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.CORE_PIN_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          authenticated_login="$(gh api user --jq .login)"
+          if [[ "${authenticated_login}" != "${BOT_LOGIN}" ]]; then
+            echo "CORE_PIN_BOT_TOKEN belongs to ${authenticated_login}, expected ${BOT_LOGIN}." >&2
+            exit 1
+          fi
+
+      - name: Create core pin commit
+        if: steps.prepare.outputs.skip == 'false'
+        id: commit
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          update_worktree="${RUNNER_TEMP}/core-pin-${TARGET_BRANCH}"
+          git worktree add --detach "${update_worktree}" "refs/remotes/origin/${TARGET_BRANCH}"
+
+          python3 .github/scripts/update_core_pin.py \
+            --repository "${update_worktree}" \
+            --core-sha "${CORE_SHA}" \
+            --author-name "${BOT_NAME}" \
+            --author-email "${BOT_EMAIL}"
+
+          echo "worktree=${update_worktree}" >> "${GITHUB_OUTPUT}"
+
+      - name: Push core pin commit
+        if: steps.prepare.outputs.skip == 'false'
+        shell: bash
+        env:
+          CORE_PIN_BOT_TOKEN: ${{ secrets.CORE_PIN_BOT_TOKEN }}
+          UPDATE_WORKTREE: ${{ steps.commit.outputs.worktree }}
+        run: |
+          set -euo pipefail
+
+          basic_auth="$(printf 'x-access-token:%s' "${CORE_PIN_BOT_TOKEN}" | base64 -w 0)"
+          echo "::add-mask::${basic_auth}"
+          git -C "${UPDATE_WORKTREE}" \
+            -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${basic_auth}" \
+            push "https://github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${TARGET_BRANCH}"

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ an `/ae2webintegration auth <token>` command. The player must run that command i
 Create a Discord webhook and set its URL as `discord_webhook` in the AE2 Web Integration config. You can also
 set `discord_role_id` if a role should be pinged on errors.
 
+Crafting completion notifications can be filtered with `discord_minimum_crafting_duration_seconds` and
+`discord_minimum_crafting_amount`. A notification must meet both configured minimums. Both values default to `0`,
+which keeps all crafting completion notifications enabled.
+
 <img width="467" height="224" alt="AE2 Web Integration Discord message" src="https://github.com/user-attachments/assets/f9f7635d-676c-40a3-8334-f7fa35e5867a" />
 
 ## Custom website

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/config/Config.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/config/Config.java
@@ -48,6 +48,14 @@ public class Config {
         return ConfigBootstrap.discordRoleIdValue.get();
     }
 
+    public static int DISCORD_MINIMUM_CRAFTING_DURATION_SECONDS() {
+        return ConfigBootstrap.discordMinimumCraftingDurationSecondsValue.get();
+    }
+
+    public static int DISCORD_MINIMUM_CRAFTING_AMOUNT() {
+        return ConfigBootstrap.discordMinimumCraftingAmountValue.get();
+    }
+
     // Tracking
     public static boolean TRACKING_TRACK_MACHINE_CRAFTING() {
         return ConfigBootstrap.trackingTrackMachineCraftingValue.get();

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/config/ConfigBootstrap.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/config/ConfigBootstrap.java
@@ -28,6 +28,8 @@ public class ConfigBootstrap {
 
     public static IConfigValue<String> discordWebhookValue = () -> "";
     public static IConfigValue<String> discordRoleIdValue = () -> "";
+    public static IConfigValue<Integer> discordMinimumCraftingDurationSecondsValue = () -> 0;
+    public static IConfigValue<Integer> discordMinimumCraftingAmountValue = () -> 0;
 
     // --- Tracking ---
 
@@ -81,6 +83,18 @@ public class ConfigBootstrap {
             "discord_role_id",
             "",
             "Role id to ping on errors, keep empty to disable pinging (if webhook is empty it will do nothing)");
+        discordMinimumCraftingDurationSecondsValue = builder.defineInt(
+            "discord_minimum_crafting_duration_seconds",
+            0,
+            0,
+            Integer.MAX_VALUE,
+            "Minimum crafting duration in seconds required for a Discord notification (0 disables this filter)");
+        discordMinimumCraftingAmountValue = builder.defineInt(
+            "discord_minimum_crafting_amount",
+            0,
+            0,
+            Integer.MAX_VALUE,
+            "Minimum final output amount required for a Discord notification (0 disables this filter)");
 
         trackingTrackMachineCraftingValue = builder.defineBoolean(
             "track_machine_crafting",

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/discord/DiscordManager.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/discord/DiscordManager.java
@@ -40,10 +40,12 @@ public class DiscordManager extends Thread {
         }
 
         long totalSeconds = Math.round(durationMillis / 1000d);
-        long hours = totalSeconds / 3600L;
+        long days = totalSeconds / 86400L;
+        long hours = totalSeconds % 86400L / 3600L;
         long minutes = totalSeconds % 3600L / 60L;
         long seconds = totalSeconds % 60L;
 
+        if (days > 0L) return days + "d " + hours + "h " + minutes + "m " + seconds + "s";
         if (hours > 0L) return hours + "h " + minutes + "m " + seconds + "s";
         if (minutes > 0L) return minutes + "m " + seconds + "s";
         return seconds + "s";

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/discord/DiscordManager.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/discord/DiscordManager.java
@@ -34,6 +34,26 @@ public class DiscordManager extends Thread {
         toPush.offer(message);
     }
 
+    public static String formatDuration(long durationMillis) {
+        if (durationMillis < 5000L) {
+            return durationMillis / 1000d + "s";
+        }
+
+        long totalSeconds = Math.round(durationMillis / 1000d);
+        long hours = totalSeconds / 3600L;
+        long minutes = totalSeconds % 3600L / 60L;
+        long seconds = totalSeconds % 60L;
+
+        if (hours > 0L) return hours + "h " + minutes + "m " + seconds + "s";
+        if (minutes > 0L) return minutes + "m " + seconds + "s";
+        return seconds + "s";
+    }
+
+    public static boolean shouldPostCraftingNotification(long durationMillis, long craftedAmount) {
+        long minimumDurationMillis = Config.DISCORD_MINIMUM_CRAFTING_DURATION_SECONDS() * 1000L;
+        return durationMillis >= minimumDurationMillis && craftedAmount >= Config.DISCORD_MINIMUM_CRAFTING_AMOUNT();
+    }
+
     public static class DiscordEmbed {
 
         String title;

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/tracking/AE2JobTracker.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/tracking/AE2JobTracker.java
@@ -236,10 +236,10 @@ public class AE2JobTracker {
         info.isDone = true;
         info.timeDone = System.currentTimeMillis();
         gridData.trackingInfo.trackingInfos.put(gridData.trackingInfo.nextFreeTrackingInfoID++, info);
-        double took = info.timeDone - info.timeStarted;
-        took /= 1000d;
+        long durationMillis = info.timeDone - info.timeStarted;
+        long craftedAmount = info.finalOutput.web$amount();
         if (!Config.AE_PUBLIC_MODE() && !Config.DISCORD_WEBHOOK()
-            .isEmpty()) {
+            .isEmpty() && DiscordManager.shouldPostCraftingNotification(durationMillis, craftedAmount)) {
             IAESecurityGrid securityGrid = grid.web$getSecurityGrid();
             if (securityGrid != null && securityGrid.web$isAvailable()) {
                 IAECraftingGrid craftingGrid = grid.web$getCraftingGrid();
@@ -253,12 +253,11 @@ public class AE2JobTracker {
                         "Crafting for `" + info.finalOutput.web$what()
                             .web$getDisplayName()
                             + " x"
-                            + info.finalOutput.web$amount()
+                            + craftedAmount
                             + "` "
                             + (info.wasCancelled ? "cancelled" : "completed")
                             + "!\nIt took "
-                            + took
-                            + "s",
+                            + DiscordManager.formatDuration(durationMillis),
                         info.wasCancelled ? 15548997 : 5763719));
             }
         }

--- a/src/test/java/pl/kuba6000/ae2webintegration/core/ConfigBootstrapTest.java
+++ b/src/test/java/pl/kuba6000/ae2webintegration/core/ConfigBootstrapTest.java
@@ -26,6 +26,8 @@ class ConfigBootstrapTest {
         ConfigBootstrap.checkForUpdatesValue = () -> true;
         ConfigBootstrap.discordWebhookValue = () -> "";
         ConfigBootstrap.discordRoleIdValue = () -> "";
+        ConfigBootstrap.discordMinimumCraftingDurationSecondsValue = () -> 0;
+        ConfigBootstrap.discordMinimumCraftingAmountValue = () -> 0;
         ConfigBootstrap.trackingTrackMachineCraftingValue = () -> false;
     }
 
@@ -34,8 +36,8 @@ class ConfigBootstrapTest {
         RecordingConfigBuilder builder = new RecordingConfigBuilder();
         ConfigBootstrap.init(builder);
 
-        // Should have exactly 10 config key definitions
-        assertEquals(10, builder.calls.size(), "expected exactly 10 config key definitions");
+        // Should have exactly 12 config key definitions
+        assertEquals(12, builder.calls.size(), "expected exactly 12 config key definitions");
 
         // Verify all expected keys with their types
         assertContainsCall("int", "port", builder.calls);
@@ -47,6 +49,8 @@ class ConfigBootstrapTest {
         assertContainsCall("boolean", "check_for_updates", builder.calls);
         assertContainsCall("string", "discord_webhook", builder.calls);
         assertContainsCall("string", "discord_role_id", builder.calls);
+        assertContainsCall("int", "discord_minimum_crafting_duration_seconds", builder.calls);
+        assertContainsCall("int", "discord_minimum_crafting_amount", builder.calls);
         assertContainsCall("boolean", "track_machine_crafting", builder.calls);
     }
 
@@ -64,6 +68,12 @@ class ConfigBootstrapTest {
                     break;
                 case "max_requests_before_logged_in_per_minute":
                     assertEquals(20, call.defValue, "max_requests default");
+                    break;
+                case "discord_minimum_crafting_duration_seconds":
+                case "discord_minimum_crafting_amount":
+                    assertEquals(0, call.defValue, call.key + " default");
+                    assertEquals(0, call.min, call.key + " min");
+                    assertEquals(Integer.MAX_VALUE, call.max, call.key + " max");
                     break;
                 case "allow_no_password_on_localhost":
                 case "public_mode":
@@ -113,6 +123,16 @@ class ConfigBootstrapTest {
         assertEquals(true, ConfigBootstrap.checkForUpdatesValue.get(), "CHECK_FOR_UPDATES");
         assertEquals("", ConfigBootstrap.discordWebhookValue.get(), "DISCORD_WEBHOOK");
         assertEquals("", ConfigBootstrap.discordRoleIdValue.get(), "DISCORD_ROLE_ID");
+        assertEquals(
+            0,
+            ConfigBootstrap.discordMinimumCraftingDurationSecondsValue.get()
+                .intValue(),
+            "DISCORD_MINIMUM_CRAFTING_DURATION_SECONDS");
+        assertEquals(
+            0,
+            ConfigBootstrap.discordMinimumCraftingAmountValue.get()
+                .intValue(),
+            "DISCORD_MINIMUM_CRAFTING_AMOUNT");
         assertEquals(false, ConfigBootstrap.trackingTrackMachineCraftingValue.get(), "TRACK_MACHINE_CRAFTING");
         // Password should be a non-empty random string (generated at init time)
         String password = ConfigBootstrap.aePasswordValue.get();

--- a/src/test/java/pl/kuba6000/ae2webintegration/core/discord/DiscordManagerTest.java
+++ b/src/test/java/pl/kuba6000/ae2webintegration/core/discord/DiscordManagerTest.java
@@ -1,0 +1,57 @@
+package pl.kuba6000.ae2webintegration.core.discord;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import pl.kuba6000.ae2webintegration.core.api.IConfigValue;
+import pl.kuba6000.ae2webintegration.core.config.ConfigBootstrap;
+
+class DiscordManagerTest {
+
+    private IConfigValue<Integer> previousMinimumDuration;
+    private IConfigValue<Integer> previousMinimumAmount;
+
+    @BeforeEach
+    void resetConfig() {
+        previousMinimumDuration = ConfigBootstrap.discordMinimumCraftingDurationSecondsValue;
+        previousMinimumAmount = ConfigBootstrap.discordMinimumCraftingAmountValue;
+        ConfigBootstrap.discordMinimumCraftingDurationSecondsValue = () -> 0;
+        ConfigBootstrap.discordMinimumCraftingAmountValue = () -> 0;
+    }
+
+    @AfterEach
+    void restoreConfig() {
+        ConfigBootstrap.discordMinimumCraftingDurationSecondsValue = previousMinimumDuration;
+        ConfigBootstrap.discordMinimumCraftingAmountValue = previousMinimumAmount;
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "250, 0.25s", "3285, 3.285s", "47000, 47s", "800000, '13m 20s'", "3661000, '1h 1m 1s'",
+        "7509000, '2h 5m 9s'" })
+    void formatsCraftingDurationForDiscord(long durationMillis, String expected) {
+        assertEquals(expected, DiscordManager.formatDuration(durationMillis));
+    }
+
+    @Test
+    void durationThresholdFiltersShortCraftingJobs() {
+        ConfigBootstrap.discordMinimumCraftingDurationSecondsValue = () -> 300;
+
+        assertFalse(DiscordManager.shouldPostCraftingNotification(299_999L, 1L));
+        assertTrue(DiscordManager.shouldPostCraftingNotification(300_000L, 1L));
+    }
+
+    @Test
+    void amountThresholdFiltersSmallCraftingJobs() {
+        ConfigBootstrap.discordMinimumCraftingAmountValue = () -> 1000;
+
+        assertFalse(DiscordManager.shouldPostCraftingNotification(1L, 999L));
+        assertTrue(DiscordManager.shouldPostCraftingNotification(1L, 1000L));
+    }
+}

--- a/src/test/java/pl/kuba6000/ae2webintegration/core/discord/DiscordManagerTest.java
+++ b/src/test/java/pl/kuba6000/ae2webintegration/core/discord/DiscordManagerTest.java
@@ -34,7 +34,7 @@ class DiscordManagerTest {
 
     @ParameterizedTest
     @CsvSource({ "250, 0.25s", "3285, 3.285s", "47000, 47s", "800000, '13m 20s'", "3661000, '1h 1m 1s'",
-        "7509000, '2h 5m 9s'" })
+        "7509000, '2h 5m 9s'", "86400000, '1d 0h 0m 0s'", "183845000, '2d 3h 4m 5s'" })
     void formatsCraftingDurationForDiscord(long durationMillis, String expected) {
         assertEquals(expected, DiscordManager.formatDuration(durationMillis));
     }


### PR DESCRIPTION
## Summary

- add independent minimum crafting duration and amount settings for Discord completion notifications
- require both configured inclusive thresholds to pass while preserving existing behavior with zero defaults
- format crafting durations in a compact human-readable form
- automatically update the core gitlink on all four adapter branches after a successful current core build
- verify the bot identity, skip obsolete or already-applied updates, and use normal non-force pushes
- restrict ordinary core workflows to read-only repository permissions and run updater tests in CI

Closes #55
Closes #56

## Verification

- full core Gradle test suite
- updater unit tests and temporary-repository integration tests
- Spotless
- actionlint
- git diff --check