### PR TITLE
fix: guard tracking serialization against null dereference/NaN and improve HTTP stability

### DIFF
--- a/src/main/java/pl/kuba6000/ae2webintegration/core/AE2Controller.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/AE2Controller.java
@@ -985,7 +985,6 @@ public class AE2Controller {
                     if (is == null) return;
 
                     byte[] raw_response = IOUtils.toByteArray(is);
-                    is.read(raw_response);
                     t.sendResponseHeaders(200, raw_response.length);
                     OutputStream os = t.getResponseBody();
                     os.write(raw_response);

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/ae2request/sync/GetCPU.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/ae2request/sync/GetCPU.java
@@ -84,10 +84,12 @@ public class GetCPU extends ISyncedRequest {
                     compactedItem.timeSpentCrafting += trackingInfo.getTimeSpentOn(key);
                     compactedItem.craftedTotal += trackingInfo.craftedTotal.getOrDefault(key, 0L);
                     compactedItem.shareInCraftingTime += trackingInfo.getShareInCraftingTime(key);
-                    compactedItem.shareInCraftingTimeCombined = Math
-                        .min(((double) compactedItem.timeSpentCrafting) / (double) clusterData.timeElapsed, 1d);
-                    compactedItem.craftsPerSec = (double) compactedItem.craftedTotal
-                        / (compactedItem.timeSpentCrafting / 1000d);
+                    compactedItem.shareInCraftingTimeCombined = clusterData.timeElapsed > 0
+                        ? Math.min(((double) compactedItem.timeSpentCrafting) / (double) clusterData.timeElapsed, 1d)
+                        : 0d;
+                    compactedItem.craftsPerSec = compactedItem.timeSpentCrafting > 0
+                        ? (double) compactedItem.craftedTotal / (compactedItem.timeSpentCrafting / 1000d)
+                        : 0d;
                 }
             }
 

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/api/JSON_CompactedJobTrackingInfo.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/api/JSON_CompactedJobTrackingInfo.java
@@ -67,12 +67,17 @@ public class JSON_CompactedJobTrackingInfo {
             item.itemid = key.web$getItemID();
             item.itemname = key.web$getDisplayName();
             item.timeSpentOn = spent;
-            item.craftedTotal = info.craftedTotal.get(key);
+            item.craftedTotal = info.craftedTotal.getOrDefault(key, 0L);
             item.shareInCraftingTime = info.getShareInCraftingTime(key);
-            item.shareInCraftingTimeCombined = Math.min(((double) item.timeSpentOn) / (double) elapsed, 1d);
-            item.craftsPerSec = (double) item.craftedTotal / (item.timeSpentOn / 1000d);
-            for (Pair<Long, Long> longLongPair : info.itemShare.get(key)) {
-                item.timings.add(new timingClass(longLongPair.getKey(), longLongPair.getValue()));
+            item.shareInCraftingTimeCombined = elapsed > 0
+                ? Math.min(((double) item.timeSpentOn) / (double) elapsed, 1d)
+                : 0d;
+            item.craftsPerSec = item.timeSpentOn > 0 ? (double) item.craftedTotal / (item.timeSpentOn / 1000d) : 0d;
+            ArrayList<Pair<Long, Long>> itemTimings = info.itemShare.get(key);
+            if (itemTimings != null) {
+                for (Pair<Long, Long> longLongPair : itemTimings) {
+                    item.timings.add(new timingClass(longLongPair.getKey(), longLongPair.getValue()));
+                }
             }
             items.add(item);
         }

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/discord/DiscordManager.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/discord/DiscordManager.java
@@ -2,10 +2,10 @@ package pl.kuba6000.ae2webintegration.core.discord;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentLinkedQueue;
-
-import javax.net.ssl.HttpsURLConnection;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -95,18 +95,18 @@ public class DiscordManager extends Thread {
         try {
             url = new URL(Config.DISCORD_WEBHOOK());
 
-            HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.addRequestProperty("Content-Type", "application/json");
             connection.addRequestProperty("User-Agent", "AE2-Web-Integration");
             connection.setDoOutput(true);
             connection.setRequestMethod("POST");
 
-            OutputStream stream = connection.getOutputStream();
-            stream.write(
-                json.toString()
-                    .getBytes());
-            stream.flush();
-            stream.close();
+            try (OutputStream stream = connection.getOutputStream()) {
+                stream.write(
+                    json.toString()
+                        .getBytes(StandardCharsets.UTF_8));
+                stream.flush();
+            }
 
             int code;
             if ((code = connection.getResponseCode()) != 200 && code != 204) {

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/tracking/AE2JobTracker.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/tracking/AE2JobTracker.java
@@ -242,8 +242,6 @@ public class AE2JobTracker {
             .isEmpty() && DiscordManager.shouldPostCraftingNotification(durationMillis, craftedAmount)) {
             IAESecurityGrid securityGrid = grid.web$getSecurityGrid();
             if (securityGrid != null && securityGrid.web$isAvailable()) {
-                IAECraftingGrid craftingGrid = grid.web$getCraftingGrid();
-                craftingGrid.web$getCPUs();
                 DiscordManager.postMessageNonBlocking(
                     new DiscordManager.DiscordEmbed(
                         "AE2 Job Tracker [ Grid " + securityGrid.web$getSecurityKey()

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/utils/VersionChecker.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/utils/VersionChecker.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -67,8 +68,12 @@ public class VersionChecker {
         lastChecked = System.currentTimeMillis();
         try {
             HttpURLConnection conn = (HttpURLConnection) new URL(versionCheckURL).openConnection();
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+            conn.setRequestProperty("User-Agent", "AE2-Web-Integration");
             if (conn.getResponseCode() == 200) {
-                try (BufferedReader buf = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+                try (BufferedReader buf = new BufferedReader(
+                    new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
                     JsonElement element = new JsonParser().parse(buf);
                     // this should be sorted right?
                     for (JsonElement tag : element.getAsJsonArray()) {


### PR DESCRIPTION
### Changes Proposed:
**Fixes & Stability:**
* Guarded `craftsPerSec` and `shareInCraftingTimeCombined` calculations in `JSON_CompactedJobTrackingInfo` and `GetCPU` to prevent `Double.NaN` and `Double.POSITIVE_INFINITY` from throwing `IllegalArgumentException` during Gson serialization when tracking intervals are 0.
* Replaced direct unboxed `info.craftedTotal.get(key)` with `getOrDefault` and added null checks on `info.itemShare.get(key)` in `JSON_CompactedJobTrackingInfo` to prevent `NullPointerException`s.
* Added the mandatory `User-Agent` header, connect/read timeouts, and explicit UTF-8 charset to `VersionChecker` to fix HTTP 403 Forbidden responses from the GitHub API and prevent unbounded worker thread blocking.
* Switched `DiscordManager` from `HttpsURLConnection` to `HttpURLConnection` to support HTTP-based webhook relays/proxies, enforced UTF-8 payload encoding, and wrapped output streams in try-with-resources.

**Performance & Chores:**
* Removed redundant `is.read(raw_response)` in `AE2Controller.WebHandler` following `IOUtils.toByteArray(is)`.
* Removed discarded `craftingGrid.web$getCPUs()` call in `AE2JobTracker.completeCrafting`.

### Safety & Impact:
* All changes are strictly scoped and backwards-compatible.
* Existing public APIs and data contracts remain unmodified.