### PR TITLE
Use release manifests for update checks and automate feed publication

### DIFF
--- a/.github/scripts/tests/test_update_release_feed.py
+++ b/.github/scripts/tests/test_update_release_feed.py
@@ -1,0 +1,162 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "update_release_feed.py"
+TARGETS = ("1.7.10", "1.12.2", "1.20.1", "1.21.1")
+REPO_URL = "https://github.com/kuba6000/AE2-Web-Integration"
+
+
+def release(tag, **overrides):
+    result = {
+        "tag_name": tag,
+        "draft": False,
+        "prerelease": False,
+        "published_at": "2026-09-07T12:00:00Z",
+        "html_url": f"{REPO_URL}/releases/tag/{tag}",
+        "assets": [{
+            "name": f"ae2webintegration-{tag}{suffix}.jar",
+            "state": "uploaded",
+            "size": 1024,
+            "browser_download_url": f"{REPO_URL}/releases/download/{tag}/ae2webintegration-{tag}{suffix}.jar",
+        } for suffix in ("-dev", "-sources", "-slim", "")],
+    }
+    result.update(overrides)
+    return result
+
+
+class UpdateReleaseFeedTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repository = Path(self.temporary.name) / "version"
+        self.repository.mkdir()
+        self.git("init")
+        for target in TARGETS:
+            (self.repository / f"{target}.json").write_text(json.dumps({
+                "version": target, "releases": {"stable": None, "prerelease": None},
+            }) + "\n", encoding="utf-8")
+        self.git("add", ".")
+        self.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                 "-c", "commit.gpgsign=false", "commit", "-m", "Initialize feed")
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def git(self, *args):
+        return subprocess.run(["git", "-C", str(self.repository), *args],
+                              capture_output=True, text=True, check=True).stdout.strip()
+
+    def update(self, releases):
+        source = Path(self.temporary.name) / "releases.json"
+        source.write_text(json.dumps(releases), encoding="utf-8")
+        return subprocess.run([sys.executable, str(SCRIPT), "--repository", str(self.repository),
+                               "--releases", str(source), "--author-name", "Release Bot",
+                               "--author-email", "bot@example.invalid"], capture_output=True, text=True)
+
+    def feed(self, target="1.7.10"):
+        return json.loads((self.repository / f"{target}.json").read_text(encoding="utf-8"))
+
+    def test_publishes_stable_and_pre_with_production_asset_and_unix_seconds(self):
+        result = self.update([release("1.0.2-forge-1.7.10"), release("1.1.0-forge-pre-1.7.10")])
+        self.assertEqual(0, result.returncode, result.stderr)
+        channels = self.feed()["releases"]
+        self.assertEqual("1.0.2", channels["stable"]["newest"])
+        self.assertEqual("1.1.0", channels["prerelease"]["newest"])
+        self.assertEqual(1788782400, channels["prerelease"]["timestamp"])
+        self.assertTrue(channels["prerelease"]["github_release_download_url"].endswith("1.1.0-forge-pre-1.7.10.jar"))
+        self.assertEqual("1.7.10.json", self.git("diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"))
+        self.assertEqual("Release Bot|bot@example.invalid", self.git("log", "-1", "--format=%an|%ae"))
+        self.assertEqual("", self.git("status", "--porcelain"))
+
+    def test_delayed_older_release_cannot_replace_newer_recommendation(self):
+        self.assertEqual(0, self.update([release("1.10.0-forge-1.7.10")]).returncode)
+        before = self.git("rev-parse", "HEAD")
+        result = self.update([release("1.9.0-forge-1.7.10", published_at="2026-09-08T12:00:00Z")])
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(before, self.git("rev-parse", "HEAD"))
+
+    def test_reconcile_includes_all_targets_and_preserves_other_channel(self):
+        self.assertEqual(0, self.update([release("1.2.0-forge-pre-1.7.10")]).returncode)
+        pre = self.feed()["releases"]["prerelease"]
+        result = self.update([release("1.1.0-forge-1.7.10"), release("1.1.0-forge-1.12.2"),
+                              release("1.1.0-forge-1.20.1"), release("1.1.0-neoforge-1.21.1")])
+        self.assertEqual(0, result.returncode, result.stderr)
+        for target in TARGETS:
+            self.assertEqual("1.1.0", self.feed(target)["releases"]["stable"]["newest"])
+        self.assertEqual(pre, self.feed()["releases"]["prerelease"])
+
+    def test_rerun_is_idempotent_and_ignores_drafts_missing_assets_and_snapshots(self):
+        releases = [release("1.0.0-forge-1.7.10"),
+                    release("2.0.0-forge-1.7.10", draft=True),
+                    release("3.0.0-forge-1.7.10", assets=[]),
+                    release("4.0.0-snapshot-forge-1.7.10")]
+        self.assertEqual(0, self.update(releases).returncode)
+        before = self.git("rev-parse", "HEAD")
+        result = self.update(releases)
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(before, self.git("rev-parse", "HEAD"))
+        self.assertEqual("1.0.0", self.feed()["releases"]["stable"]["newest"])
+
+    def test_ordered_prereleases_use_numeric_identifiers_not_publication_time(self):
+        self.assertEqual(0, self.update([release("1.2.0-beta.2-forge-1.7.10")]).returncode)
+        result = self.update([release("1.2.0-beta.10-forge-1.7.10", published_at="2026-09-06T12:00:00Z")])
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("1.2.0-beta.10", self.feed()["releases"]["prerelease"]["newest"])
+
+    def test_old_alpha_is_not_introduced_as_active_recommendation(self):
+        result = self.update([release("1.0.0-forge-1.7.10"), release("0.2.1-alpha-forge-1.7.10")])
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIsNone(self.feed()["releases"]["prerelease"])
+
+    def test_unordered_same_base_pre_does_not_replace_existing_record(self):
+        self.assertEqual(0, self.update([release("1.2.0-forge-pre-1.7.10")]).returncode)
+        before = self.git("rev-parse", "HEAD")
+        result = self.update([release("1.2.0-GTNH-Native-Fluids-Support-forge-pre-1.7.10")])
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(before, self.git("rev-parse", "HEAD"))
+
+    def test_only_uploaded_production_artifact_is_eligible(self):
+        no_production = release("1.0.0-forge-1.7.10")
+        no_production["assets"].pop()
+        uploading = release("2.0.0-forge-1.7.10")
+        uploading["assets"][-1]["state"] = "starter"
+        result = self.update([no_production, uploading])
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIsNone(self.feed()["releases"]["stable"])
+
+    def test_dirty_feed_is_not_committed_with_release_update(self):
+        (self.repository / "1.12.2.json").write_text("uncommitted", encoding="utf-8")
+        before = self.git("rev-parse", "HEAD")
+        result = self.update([release("1.0.0-forge-1.7.10")])
+        self.assertNotEqual(0, result.returncode)
+        self.assertEqual(before, self.git("rev-parse", "HEAD"))
+        self.assertIsNone(self.feed()["releases"]["stable"])
+
+    def test_ambiguous_new_prereleases_require_explicit_choice(self):
+        self.assertEqual(0, self.update([release("1.1.0-forge-pre-1.7.10")]).returncode)
+        before = self.git("rev-parse", "HEAD")
+        result = self.update([release("1.2.0-zeta-forge-1.7.10"), release("1.2.0-alpha-forge-1.7.10")])
+        self.assertNotEqual(0, result.returncode)
+        self.assertEqual(before, self.git("rev-parse", "HEAD"))
+        self.assertEqual("1.1.0", self.feed()["releases"]["prerelease"]["newest"])
+
+    def test_semver_build_metadata_does_not_change_release_order(self):
+        result = self.update([release("1.2.0+build.2-forge-1.7.10")])
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("1.2.0+build.2", self.feed()["releases"]["stable"]["newest"])
+
+    def test_invalid_semver_suffix_is_not_published(self):
+        for version in ("1.2.0-beta..2", "1.2.0-beta.02", "1.2.0+build..2"):
+            with self.subTest(version=version):
+                before = self.git("rev-parse", "HEAD")
+                result = self.update([release(f"{version}-forge-1.7.10")])
+                self.assertNotEqual(0, result.returncode)
+                self.assertEqual(before, self.git("rev-parse", "HEAD"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/update_release_feed.py
+++ b/.github/scripts/update_release_feed.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Advance the JSON feed from published GitHub releases and commit changed files."""
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+
+TARGETS = {"1.7.10": "forge", "1.12.2": "forge", "1.20.1": "forge", "1.21.1": "neoforge"}
+VERSION = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?")
+ORDERED_PRE = re.compile(r"[a-zA-Z][a-zA-Z0-9-]*\.[0-9]+(?:\.[0-9]+)*")
+TAG = re.compile(r"(.+)-(forge|neoforge)(-pre)?-(1\.7\.10|1\.12\.2|1\.20\.1|1\.21\.1)(-pre)?")
+
+
+def git(repository, *args):
+    return subprocess.run(["git", "-C", str(repository), *args],
+                          capture_output=True, text=True, check=True).stdout.strip()
+
+
+def version_key(value):
+    match = VERSION.fullmatch(value)
+    if not match:
+        raise ValueError(f"Unsupported release version: {value}")
+    if match[4] is not None and any(not part or re.fullmatch(r"0[0-9]+", part) for part in match[4].split(".")):
+        raise ValueError(f"Invalid prerelease identifiers: {value}")
+    if match[5] is not None and any(not part for part in match[5].split(".")):
+        raise ValueError(f"Invalid build metadata: {value}")
+    return tuple(int(match[i]) for i in (1, 2, 3)), match[4]
+
+
+def newer(candidate, current):
+    if current is None:
+        return True
+    left, left_pre = version_key(candidate["newest"])
+    right, right_pre = version_key(current["newest"])
+    if left != right:
+        return left > right
+    # Shipped descriptive/unnumbered prereleases have no reliable order within the same base.
+    if not all(suffix and ORDERED_PRE.fullmatch(suffix) for suffix in (left_pre, right_pre)):
+        return False
+    def identifiers(suffix):
+        return tuple((0, int(part)) if part.isdigit() else (1, part) for part in suffix.split("."))
+    return identifiers(left_pre) > identifiers(right_pre)
+
+
+def release_record(release):
+    if release["draft"]:
+        return None
+    tag = release["tag_name"]
+    match = TAG.fullmatch(tag)
+    if not match or "snapshot" in tag.lower():
+        return None
+    newest, loader, pre_before, target, pre_after = match.groups()
+    if TARGETS[target] != loader:
+        return None
+    _, suffix = version_key(newest)
+    channel = "prerelease" if release["prerelease"] or pre_before or pre_after or suffix else "stable"
+    assets = [asset for asset in release["assets"]
+              if asset["name"] == f"ae2webintegration-{tag}.jar"
+              and asset["state"] == "uploaded" and asset["size"] > 0]
+    if not assets:
+        return None
+    if len(assets) != 1:
+        raise ValueError(f"Ambiguous production JAR for {tag}")
+    published = datetime.fromisoformat(release["published_at"].replace("Z", "+00:00"))
+    if published.tzinfo is None:
+        raise ValueError(f"Missing publication timezone for {tag}")
+    return target, channel, {
+        "newest": newest,
+        "timestamp": int(published.timestamp()),
+        "github_release_tag": tag,
+        "github_release_url": release["html_url"],
+        "github_release_download_url": assets[0]["browser_download_url"],
+    }
+
+
+def recommendation(records, current):
+    by_tag = {current["github_release_tag"]: current} if current is not None else {}
+    by_tag.update((record["github_release_tag"], record) for record in records)
+    if not by_tag:
+        return None
+    newest_base = max(version_key(record["newest"])[0] for record in by_tag.values())
+    candidates = [record for record in by_tag.values() if version_key(record["newest"])[0] == newest_base]
+    candidates = [record for record in candidates if not any(newer(other, record) for other in candidates)]
+    if len(candidates) == 1:
+        return candidates[0]
+    if current is not None:
+        for record in candidates:
+            if record["github_release_tag"] == current["github_release_tag"]:
+                return record
+    raise ValueError("Ambiguous release order; use numbered prereleases or choose the feed record manually: "
+                     + ", ".join(record["github_release_tag"] for record in candidates))
+
+
+def update(repository, releases, author_name, author_email):
+    if git(repository, "status", "--porcelain", "--untracked-files=all"):
+        raise ValueError("Version worktree must be clean")
+    feeds = {}
+    for target in TARGETS:
+        path = repository / f"{target}.json"
+        feed = json.loads(path.read_text(encoding="utf-8"))
+        if feed["version"] != target:
+            raise ValueError(f"Incorrect Minecraft target in {path}")
+        feeds[target] = feed
+    original = json.dumps(feeds, sort_keys=True)
+    records = [record for release in releases if (record := release_record(release)) is not None]
+    for target, feed in feeds.items():
+        channels = feed["releases"]
+        # Stable first, to avoid introducing superseded historical pre releases into empty channels.
+        for channel in ("stable", "prerelease"):
+            candidates = [record for mc, kind, record in records if mc == target and kind == channel]
+            if channel == "prerelease" and channels[channel] is None and channels["stable"] is not None:
+                stable_base = version_key(channels["stable"]["newest"])[0]
+                candidates = [record for record in candidates if version_key(record["newest"])[0] > stable_base]
+            channels[channel] = recommendation(candidates, channels[channel])
+    if json.dumps(feeds, sort_keys=True) == original:
+        print("Release feed is already current")
+        return
+    for target, feed in feeds.items():
+        path = repository / f"{target}.json"
+        # Leave unchanged files byte-for-byte intact, including their formatting.
+        if json.loads(path.read_text(encoding="utf-8")) != feed:
+            path.write_text(json.dumps(feed, indent=2) + "\n", encoding="utf-8")
+            git(repository, "add", "--", path.name)
+    git(repository, "-c", f"user.name={author_name}", "-c", f"user.email={author_email}",
+        "-c", "commit.gpgsign=false", "commit", "-m", "Update published release feed")
+    print("Committed updated release feed")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", type=Path, required=True)
+    parser.add_argument("--releases", type=Path, required=True)
+    parser.add_argument("--author-name", required=True)
+    parser.add_argument("--author-email", required=True)
+    args = parser.parse_args()
+    update(args.repository, json.loads(args.releases.read_text(encoding="utf-8")),
+           args.author_name, args.author_email)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout core
         uses: actions/checkout@v4
 
-      - name: Test core pin updater
+      - name: Test repository automation
         run: python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py' -v
 
       - name: Set up JDK

--- a/.github/workflows/update-release-feed.yml
+++ b/.github/workflows/update-release-feed.yml
@@ -1,0 +1,91 @@
+name: Update release feed
+
+on:
+  workflow_run:
+    workflows: [ Release tagged build ]
+    types: [ completed ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Every run reconciles all published releases, including any whose pending run was replaced.
+concurrency:
+  group: update-release-feed
+  cancel-in-progress: false
+
+jobs:
+  update-release-feed:
+    if: >-
+      github.repository == 'kuba6000/AE2-Web-Integration' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_repository.full_name == github.repository))
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      BOT_EMAIL: agent@kuba6000.pl
+      BOT_LOGIN: kuba6000-agent
+      BOT_NAME: "KLANKER | kuba6000"
+
+    steps:
+      - name: Checkout trusted core automation
+        uses: actions/checkout@v4
+        with:
+          ref: core
+          persist-credentials: false
+          submodules: false
+
+      - name: Checkout version feed
+        uses: actions/checkout@v4
+        with:
+          ref: version
+          path: version-feed
+          persist-credentials: false
+
+      - name: Verify bot token identity
+        env:
+          GH_TOKEN: ${{ secrets.CORE_PIN_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          authenticated_login="$(gh api user --jq .login)"
+          if [[ "${authenticated_login}" != "${BOT_LOGIN}" ]]; then
+            echo "CORE_PIN_BOT_TOKEN belongs to ${authenticated_login}, expected ${BOT_LOGIN}." >&2
+            exit 1
+          fi
+
+      - name: Reconcile and publish release feed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CORE_PIN_BOT_TOKEN: ${{ secrets.CORE_PIN_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          basic_auth="$(printf 'x-access-token:%s' "${CORE_PIN_BOT_TOKEN}" | base64 -w 0)"
+          echo "::add-mask::${basic_auth}"
+
+          for attempt in 1 2 3 4 5; do
+            git -C version-feed fetch --no-tags origin refs/heads/version
+            git -C version-feed reset --hard FETCH_HEAD
+            previous_sha="$(git -C version-feed rev-parse HEAD)"
+
+            gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              | jq 'add' > "${RUNNER_TEMP}/published-releases.json"
+            python3 .github/scripts/update_release_feed.py \
+              --repository version-feed \
+              --releases "${RUNNER_TEMP}/published-releases.json" \
+              --author-name "${BOT_NAME}" \
+              --author-email "${BOT_EMAIL}"
+
+            if [[ "$(git -C version-feed rev-parse HEAD)" == "${previous_sha}" ]]; then
+              exit 0
+            fi
+            if git -C version-feed \
+              -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${basic_auth}" \
+              push "https://github.com/${GITHUB_REPOSITORY}.git" HEAD:refs/heads/version; then
+              exit 0
+            fi
+            echo "Push failed; refreshing version branch before retry ${attempt}/5."
+          done
+          echo "Unable to publish release feed after five attempts." >&2
+          exit 1

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/AE2Controller.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/AE2Controller.java
@@ -55,7 +55,6 @@ import pl.kuba6000.ae2webintegration.core.identity.ItemIdentityRegistry;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAE;
 import pl.kuba6000.ae2webintegration.core.utils.HTTPUtils;
 import pl.kuba6000.ae2webintegration.core.utils.RateLimiter;
-import pl.kuba6000.ae2webintegration.core.utils.VersionChecker;
 
 public class AE2Controller {
 
@@ -887,7 +886,9 @@ public class AE2Controller {
                     json.addProperty("token", token);
                     json.addProperty("username", login.principal.getUsername());
                     json.addProperty("isAdmin", login.principal.isAdmin());
-                    json.addProperty("isOutdated", Config.CHECK_FOR_UPDATES() && VersionChecker.isOutdated());
+                    json.addProperty(
+                        "isOutdated",
+                        Config.CHECK_FOR_UPDATES() && CoreEngine.getAvailableUpdate() != null);
                     byte[] raw_response = json.toString()
                         .getBytes(StandardCharsets.UTF_8);
                     t.sendResponseHeaders(200, raw_response.length);
@@ -1033,7 +1034,7 @@ public class AE2Controller {
             response = response.replace("_REPLACE_ME_IS_PUBLIC_MODE", Config.AE_PUBLIC_MODE() ? "true" : "false");
             response = response.replace(
                 "_REPLACE_ME_VERSION_OUTDATED",
-                Config.CHECK_FOR_UPDATES() && VersionChecker.isOutdated() ? "true" : "false");
+                Config.CHECK_FOR_UPDATES() && CoreEngine.getAvailableUpdate() != null ? "true" : "false");
             RequestContext context = requestContext.get();
             if (context != null) {
                 response = response.replace("_REPLACE_ME_USERNAME", context.principal.getUsername());

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/CoreEngine.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/CoreEngine.java
@@ -1,16 +1,20 @@
 package pl.kuba6000.ae2webintegration.core;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 
 import pl.kuba6000.ae2webintegration.core.api.IServerPlatform;
 import pl.kuba6000.ae2webintegration.core.api.PlayerIdentity;
 import pl.kuba6000.ae2webintegration.core.config.Config;
 import pl.kuba6000.ae2webintegration.core.config.CoreData;
 import pl.kuba6000.ae2webintegration.core.tracking.AE2JobTracker;
+import pl.kuba6000.ae2webintegration.core.utils.ReleaseManifest;
 import pl.kuba6000.ae2webintegration.core.utils.VersionChecker;
 
 public class CoreEngine {
@@ -34,9 +38,14 @@ public class CoreEngine {
 
     // Populated by the interface layer from the buildscript-generated mod version.
     private static volatile String modVersion;
+    private static String versionIdentifier;
+    private static volatile @Nullable VersionChecker versionChecker;
+    private static boolean serverRunning;
 
     public static void init(IServerPlatform serverPlatform, String modVersion, String versionIdentifier) {
-        VersionChecker.setVersionIdentifier(versionIdentifier);
+        serverRunning = false;
+        stopVersionChecker();
+        CoreEngine.versionIdentifier = versionIdentifier;
         AE2Controller.serverPlatform = serverPlatform;
         Config.init(serverPlatform.getConfigDirectory());
         CoreEngine.modVersion = modVersion;
@@ -49,9 +58,10 @@ public class CoreEngine {
     }
 
     public static void onServerStarted() {
+        serverRunning = true;
         AE2Controller.init();
         StartupHandler.logOpenAdminAccessWarning();
-        StartupHandler.logOutdatedWarning();
+        maintainVersionChecker();
         StartupHandler.handleDiscordIntegration();
     }
 
@@ -63,6 +73,36 @@ public class CoreEngine {
     public static void onServerTick() {
         drainRequests(System::nanoTime);
         runPlanMaintenance(System.nanoTime());
+        maintainVersionChecker();
+    }
+
+    private static void maintainVersionChecker() {
+        if (!serverRunning) return;
+        if (!Config.CHECK_FOR_UPDATES()) {
+            stopVersionChecker();
+        } else if (versionChecker == null && modVersion != null) {
+            try {
+                versionChecker = new VersionChecker(
+                    new URL("https://raw.githubusercontent.com/kuba6000/AE2-Web-Integration/version/"),
+                    modVersion,
+                    versionIdentifier);
+                versionChecker.checkForUpdates();
+            } catch (MalformedURLException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    private static void stopVersionChecker() {
+        if (versionChecker != null) {
+            versionChecker.close();
+            versionChecker = null;
+        }
+    }
+
+    public static @Nullable ReleaseManifest.Release getAvailableUpdate() {
+        VersionChecker checker = versionChecker;
+        return checker == null ? null : checker.getAvailableUpdate();
     }
 
     /** Called from the platform's player-login event, which already runs on the server thread. */
@@ -118,12 +158,16 @@ public class CoreEngine {
     }
 
     public static void onServerStopping() {
+        serverRunning = false;
+        stopVersionChecker();
         AE2Controller.stopHTTPServer();
         // Authorization must not survive into the next world loaded in this JVM.
         GridAccessSessions.clear();
     }
 
     public static synchronized void onServerStopped() {
+        serverRunning = false;
+        stopVersionChecker();
         // Defensive when startup failed partway or a platform omits the earlier stopping callback.
         AE2Controller.stopHTTPServer();
         AE2Controller.clearWorldState();

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/StartupHandler.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/StartupHandler.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 
 import pl.kuba6000.ae2webintegration.core.config.Config;
 import pl.kuba6000.ae2webintegration.core.discord.DiscordManager;
-import pl.kuba6000.ae2webintegration.core.utils.VersionChecker;
 
 public class StartupHandler {
 
@@ -29,14 +28,6 @@ public class StartupHandler {
                 + " cancelling crafting jobs."
                 + " Set 'password' in the config to require a login."
                 + " (Access from localhost is controlled separately by 'allow_no_password_on_localhost'.)");
-    }
-
-    public static void logOutdatedWarning() {
-        if (Config.CHECK_FOR_UPDATES() && VersionChecker.isOutdated()) {
-            LOG.warn(
-                "You are not on latest version ! Consider updating to " + VersionChecker.getLatestTag()
-                    + " at https://github.com/kuba6000/AE2-Web-Integration/releases/latest");
-        }
     }
 
     public static void handleDiscordIntegration() {

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/UpdateNotifier.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/UpdateNotifier.java
@@ -3,16 +3,21 @@ package pl.kuba6000.ae2webintegration.core;
 import pl.kuba6000.ae2webintegration.core.api.IPlayerMessenger;
 import pl.kuba6000.ae2webintegration.core.api.PlayerIdentity;
 import pl.kuba6000.ae2webintegration.core.config.Config;
-import pl.kuba6000.ae2webintegration.core.utils.VersionChecker;
+import pl.kuba6000.ae2webintegration.core.utils.ReleaseManifest;
 
 public class UpdateNotifier {
 
-    private static final String UPDATE_MESSAGE = "----> AE2WebIntegration -> New version detected!"
-        + " Consider updating at https://github.com/kuba6000/AE2-Web-Integration/releases/latest";
-
     public static void notifyPlayerIfOutdated(IPlayerMessenger messenger, PlayerIdentity player) {
-        if (Config.CHECK_FOR_UPDATES() && VersionChecker.isOutdated()) {
-            messenger.sendMessage(player, UPDATE_MESSAGE);
+        if (!Config.CHECK_FOR_UPDATES()) return;
+        ReleaseManifest.Release update = CoreEngine.getAvailableUpdate();
+        if (update != null) {
+            messenger.sendMessage(
+                player,
+                "AE2 Web Integration: new "
+                    + (update.channel == ReleaseManifest.Channel.STABLE ? "stable release " : "prerelease ")
+                    + update.tag
+                    + " available at "
+                    + update.releaseUrl);
         }
     }
 

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/utils/ReleaseManifest.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/utils/ReleaseManifest.java
@@ -1,0 +1,185 @@
+package pl.kuba6000.ae2webintegration.core.utils;
+
+import java.math.BigInteger;
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/** The published recommendations for one Minecraft version. */
+public final class ReleaseManifest {
+
+    public enum Channel {
+        STABLE,
+        PRERELEASE
+    }
+
+    public static final class Release {
+
+        public final @NotNull String version;
+        public final @NotNull Channel channel;
+        /** Seconds since the Unix epoch. */
+        public final long timestamp;
+        public final @NotNull String tag;
+        public final @NotNull String releaseUrl;
+        public final @NotNull String downloadUrl;
+        private final Version comparable;
+
+        private Release(JsonObject json, Channel channel) {
+            version = string(json, "newest");
+            comparable = Version.parse(version);
+            if (comparable == null || (channel == Channel.STABLE && comparable.suffix != null)) {
+                throw new IllegalArgumentException("Invalid release version");
+            }
+            this.channel = channel;
+            String seconds = json.get("timestamp")
+                .toString();
+            if (!seconds.matches("[0-9]+")) throw new IllegalArgumentException("Expected Unix seconds");
+            timestamp = Long.parseLong(seconds);
+            tag = string(json, "github_release_tag");
+            releaseUrl = url(json, "github_release_url");
+            downloadUrl = url(json, "github_release_download_url");
+        }
+    }
+
+    private final @NotNull String minecraftVersion;
+    private final @Nullable Release stable;
+    private final @Nullable Release prerelease;
+
+    private ReleaseManifest(@NotNull String minecraftVersion, @Nullable Release stable, @Nullable Release prerelease) {
+        this.minecraftVersion = minecraftVersion;
+        this.stable = stable;
+        this.prerelease = prerelease;
+    }
+
+    public static @NotNull ReleaseManifest parse(@NotNull String json, @NotNull String minecraftVersion) {
+        JsonObject root = new JsonParser().parse(json)
+            .getAsJsonObject();
+        if (!minecraftVersion.equals(string(root, "version"))) {
+            throw new IllegalArgumentException("Release feed targets another Minecraft version");
+        }
+        JsonObject releases = root.getAsJsonObject("releases");
+        return new ReleaseManifest(
+            minecraftVersion,
+            readRelease(releases, "stable", Channel.STABLE),
+            readRelease(releases, "prerelease", Channel.PRERELEASE));
+    }
+
+    public @Nullable Release findUpdate(@NotNull String installedVersion, @NotNull String versionIdentifier) {
+        if (!versionIdentifier.endsWith("-" + minecraftVersion)) return null;
+        String loader = versionIdentifier.substring(0, versionIdentifier.length() - minecraftVersion.length());
+        Matcher platform = Pattern
+            .compile(Pattern.quote(loader) + "(pre-)?" + Pattern.quote(minecraftVersion) + "(?=$|[-+])(.*)")
+            .matcher(installedVersion);
+        boolean platformFound = platform.find();
+        if (!platformFound && Pattern.compile("-(?:neo)?forge-")
+            .matcher(installedVersion)
+            .find()) return null;
+        Version installed = Version
+            .parse(platformFound ? installedVersion.substring(0, platform.start()) : installedVersion);
+        if (installed == null) return null;
+        String tail = platformFound ? platform.group(2) : "";
+        boolean isPre = installed.suffix != null || (platformFound && platform.group(1) != null)
+            || tail.equals("-pre")
+            || tail.startsWith("-pre-")
+            || tail.startsWith("-pre+");
+        boolean development = !(tail.isEmpty() || tail.equals("-pre")) || installedVersion.contains("+");
+        Release selected = isUpgrade(stable, installed, installedVersion, isPre, development) ? stable : null;
+        if (isPre && isUpgrade(prerelease, installed, installedVersion, true, development)) {
+            if (selected == null || prerelease.comparable.compareBase(selected.comparable) > 0) selected = prerelease;
+        }
+        return selected;
+    }
+
+    private static boolean isUpgrade(@Nullable Release release, Version installed, String installedTag, boolean isPre,
+        boolean development) {
+        if (release == null || release.tag.equals(installedTag)) return false;
+        int base = release.comparable.compareBase(installed);
+        if (base != 0) return base > 0;
+        if (!isPre || development) return false;
+        if (release.channel == Channel.STABLE) return true;
+        // Old descriptive/unnumbered preview tags carry no reliable within-release ordering.
+        return release.comparable.comparePrerelease(installed) > 0;
+    }
+
+    private static @Nullable Release readRelease(JsonObject releases, String name, Channel channel) {
+        JsonElement value = releases.get(name);
+        if (value == null) throw new IllegalArgumentException("Missing release channel: " + name);
+        return value.isJsonNull() ? null : new Release(value.getAsJsonObject(), channel);
+    }
+
+    private static String string(JsonObject json, String name) {
+        JsonElement value = json.get(name);
+        if (value == null || !value.isJsonPrimitive()
+            || !value.getAsJsonPrimitive()
+                .isString()
+            || value.getAsString()
+                .isEmpty())
+            throw new IllegalArgumentException("Missing string: " + name);
+        return value.getAsString();
+    }
+
+    private static String url(JsonObject json, String name) {
+        String value = string(json, name);
+        URI uri = URI.create(value);
+        if (!"https".equals(uri.getScheme()) || !"github.com".equals(uri.getHost()) || uri.getUserInfo() != null) {
+            throw new IllegalArgumentException("Expected a GitHub HTTPS URL: " + name);
+        }
+        return value;
+    }
+
+    private static final class Version {
+
+        private static final Pattern FORMAT = Pattern.compile(
+            "(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z.-]+))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?");
+        private final BigInteger[] numbers;
+        private final @Nullable String suffix;
+
+        private Version(Matcher matcher) {
+            numbers = new BigInteger[] { new BigInteger(matcher.group(1)), new BigInteger(matcher.group(2)),
+                new BigInteger(matcher.group(3)) };
+            suffix = matcher.group(4);
+        }
+
+        private static @Nullable Version parse(String text) {
+            Matcher matcher = FORMAT.matcher(text);
+            if (!matcher.matches()) return null;
+            String suffix = matcher.group(4);
+            if (suffix != null) {
+                for (String component : suffix.split("\\.", -1)) {
+                    if (component.isEmpty() || component.matches("0[0-9]+")) return null;
+                }
+            }
+            return new Version(matcher);
+        }
+
+        private int compareBase(Version other) {
+            for (int i = 0; i < numbers.length; i++) {
+                int comparison = numbers[i].compareTo(other.numbers[i]);
+                if (comparison != 0) return comparison;
+            }
+            return 0;
+        }
+
+        private int comparePrerelease(Version other) {
+            if (suffix == null || other.suffix == null
+                || !suffix.matches("[a-zA-Z][a-zA-Z0-9-]*\\.[0-9]+(?:\\.[0-9]+)*")
+                || !other.suffix.matches("[a-zA-Z][a-zA-Z0-9-]*\\.[0-9]+(?:\\.[0-9]+)*")) return 0;
+            String[] left = suffix.split("\\.");
+            String[] right = other.suffix.split("\\.");
+            int label = left[0].compareTo(right[0]);
+            if (label != 0) return label;
+            for (int i = 1; i < Math.min(left.length, right.length); i++) {
+                int comparison = new BigInteger(left[i]).compareTo(new BigInteger(right[i]));
+                if (comparison != 0) return comparison;
+            }
+            return Integer.compare(left.length, right.length);
+        }
+    }
+}

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/utils/VersionChecker.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/utils/VersionChecker.java
@@ -24,7 +24,12 @@ import org.jetbrains.annotations.Nullable;
 public final class VersionChecker implements AutoCloseable {
 
     private static final Logger LOG = LogManager.getLogger("ae2webintegration");
+    private static final long CHECK_INTERVAL_HOURS = 5;
+    private static final long RETRY_DELAY_MINUTES = 5;
+    private static final long FETCH_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(15);
+    private static final int HTTP_TIMEOUT_MILLIS = (int) TimeUnit.SECONDS.toMillis(5);
     private static final int MAX_RESPONSE_BYTES = 64 * 1024;
+    private static final int READ_BUFFER_BYTES = 4 * 1024;
     private final @NotNull String currentVersion;
     private final @NotNull String versionIdentifier;
     private final @NotNull String minecraftVersion;
@@ -91,7 +96,7 @@ public final class VersionChecker implements AutoCloseable {
                         release.releaseUrl);
                 }
                 pending = null;
-                scheduled = executor.schedule(this::checkForUpdates, 5, TimeUnit.HOURS);
+                scheduled = executor.schedule(this::checkForUpdates, CHECK_INTERVAL_HOURS, TimeUnit.HOURS);
                 result.complete(release);
             }
         } catch (Exception e) {
@@ -99,29 +104,29 @@ public final class VersionChecker implements AutoCloseable {
                 if (closed) return;
                 LOG.debug("Could not check AE2 Web Integration releases", e);
                 pending = null;
-                scheduled = executor.schedule(this::checkForUpdates, 5, TimeUnit.MINUTES);
+                scheduled = executor.schedule(this::checkForUpdates, RETRY_DELAY_MINUTES, TimeUnit.MINUTES);
                 result.completeExceptionally(e);
             }
         }
     }
 
     private ReleaseManifest fetch() throws IOException {
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+        long deadline = System.nanoTime() + FETCH_TIMEOUT_NANOS;
         HttpURLConnection request = (HttpURLConnection) feedUrl.openConnection();
-        request.setConnectTimeout(5000);
-        request.setReadTimeout(5000);
+        request.setConnectTimeout(HTTP_TIMEOUT_MILLIS);
+        request.setReadTimeout(HTTP_TIMEOUT_MILLIS);
         request.setRequestProperty("User-Agent", "AE2-Web-Integration");
         request.setRequestProperty("Accept", "application/json");
         synchronized (this) {
             if (closed) throw new IOException("Version checker stopped");
         }
         try {
-            if (request.getResponseCode() != 200)
+            if (request.getResponseCode() != HttpURLConnection.HTTP_OK)
                 throw new IOException("Release feed HTTP status: " + request.getResponseCode());
             if (request.getContentLengthLong() > MAX_RESPONSE_BYTES) throw new IOException("Release feed is too large");
             try (InputStream input = request.getInputStream();
                 ByteArrayOutputStream body = new ByteArrayOutputStream()) {
-                byte[] bytes = new byte[4096];
+                byte[] bytes = new byte[READ_BUFFER_BYTES];
                 int length;
                 while ((length = input.read(bytes)) != -1) {
                     if (System.nanoTime() - deadline >= 0) throw new IOException("Release feed timed out");

--- a/src/main/java/pl/kuba6000/ae2webintegration/core/utils/VersionChecker.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/core/utils/VersionChecker.java
@@ -1,110 +1,147 @@
 package pl.kuba6000.ae2webintegration.core.utils;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import pl.kuba6000.ae2webintegration.core.CoreEngine;
+/** One server lifecycle's background checks and last completed recommendation. */
+public final class VersionChecker implements AutoCloseable {
 
-public class VersionChecker {
+    private static final Logger LOG = LogManager.getLogger("ae2webintegration");
+    private static final int MAX_RESPONSE_BYTES = 64 * 1024;
+    private final @NotNull String currentVersion;
+    private final @NotNull String versionIdentifier;
+    private final @NotNull String minecraftVersion;
+    private final @NotNull URL feedUrl;
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(task -> {
+        Thread thread = new Thread(task, "AE2WebIntegration-VersionChecker");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private volatile @Nullable ReleaseManifest.Release availableUpdate;
+    private @Nullable CompletableFuture<ReleaseManifest.Release> pending;
+    private @Nullable ScheduledFuture<?> scheduled;
+    private boolean closed;
 
-    // example version: 0.0.9-alpha-forge-1.12.2
-    private static String VERSION_IDENTIFIER = "";
-
-    private static final String versionCheckURL = "https://api.github.com/repos/kuba6000/AE2-Web-Integration/tags";
-    private static String latestTag = null;
-
-    private static long lastChecked = 0L;
-
-    /**
-     * Sets the version identifier used to filter GitHub tags for update checks.
-     * Must be called from the interface layer before any version check runs.
-     * Example: "-forge-1.7.10", "-forge-1.12.2", "-neoforge-1.21.1".
-     */
-    public static void setVersionIdentifier(String identifier) {
-        VERSION_IDENTIFIER = identifier;
-    }
-
-    /**
-     * Extracts the version identifier suffix from a version string when
-     * VERSION_IDENTIFIER has not been explicitly set via setVersionIdentifier().
-     * Matches patterns like -forge-1.7.10 or -neoforge-1.21.1 within the version string.
-     */
-    private static String extractVersionIdentifier(String version) {
-        Matcher matcher = Pattern.compile("-(?:forge|neoforge)-\\d+\\.\\d+\\.\\d+")
-            .matcher(version);
-        return matcher.find() ? matcher.group() : "";
-    }
-
-    private static void updateLatestVersion(String currentVersion) {
-        if (currentVersion == null || currentVersion.isEmpty()) return;
-
-        // Fallback: extract VERSION_IDENTIFIER from currentVersion if not explicitly set
-        if (VERSION_IDENTIFIER == null || VERSION_IDENTIFIER.isEmpty()) {
-            VERSION_IDENTIFIER = extractVersionIdentifier(currentVersion);
-            if (VERSION_IDENTIFIER == null || VERSION_IDENTIFIER.isEmpty()) {
-                return; // Cannot determine version identifier for this version
-            }
-        }
-
-        if (lastChecked != 0L) {
-            long elapsed = System.currentTimeMillis() - lastChecked;
-            if (latestTag == null) {
-                if (elapsed < 5 * 60 * 1000) // 5 minutes
-                    return;
-            } else if (!currentVersion.equals(latestTag)) {
-                return;
-            } else if (elapsed < 5 * 60 * 60 * 1000) { // 5 hours
-                return;
-            }
-        }
-        lastChecked = System.currentTimeMillis();
+    public VersionChecker(@NotNull URL feedBaseUrl, @NotNull String currentVersion, @NotNull String versionIdentifier) {
+        this.currentVersion = currentVersion;
+        this.versionIdentifier = versionIdentifier;
+        Matcher target = Pattern.compile("-(?:neo)?forge-(\\d+\\.\\d+\\.\\d+)")
+            .matcher(versionIdentifier);
+        if (!target.matches())
+            throw new IllegalArgumentException("Unsupported version identifier: " + versionIdentifier);
+        minecraftVersion = target.group(1);
         try {
-            HttpURLConnection conn = (HttpURLConnection) new URL(versionCheckURL).openConnection();
-            conn.setConnectTimeout(5000);
-            conn.setReadTimeout(5000);
-            conn.setRequestProperty("User-Agent", "AE2-Web-Integration");
-            if (conn.getResponseCode() == 200) {
-                try (BufferedReader buf = new BufferedReader(
-                    new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
-                    JsonElement element = new JsonParser().parse(buf);
-                    // this should be sorted right?
-                    for (JsonElement tag : element.getAsJsonArray()) {
-                        String name = tag.getAsJsonObject()
-                            .get("name")
-                            .getAsString();
-                        if (name.contains(VERSION_IDENTIFIER)) {
-                            latestTag = name;
-                            return;
-                        }
-                    }
-                    // not found???
-                    latestTag = currentVersion;
-                }
-            }
-
-        } catch (Exception ignored) {
-
+            feedUrl = new URL(feedBaseUrl, minecraftVersion + ".json");
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid feed URL", e);
         }
     }
 
-    public static boolean isOutdated() {
-        String currentVersion = CoreEngine.getModVersion();
-        if (currentVersion == null || currentVersion.isEmpty()) return false;
-        updateLatestVersion(currentVersion);
-        if (latestTag == null) return false;
-        return !latestTag.equals(currentVersion);
+    /**
+     * Starts or joins a background refresh. Successful checks repeat after five hours; failures retry in five minutes.
+     */
+    public synchronized @NotNull CompletableFuture<ReleaseManifest.Release> checkForUpdates() {
+        if (closed) {
+            CompletableFuture<ReleaseManifest.Release> cancelled = new CompletableFuture<>();
+            cancelled.cancel(false);
+            return cancelled;
+        }
+        if (pending != null) return pending;
+        if (scheduled != null) scheduled.cancel(false);
+        CompletableFuture<ReleaseManifest.Release> result = new CompletableFuture<>();
+        pending = result;
+        executor.execute(() -> refresh(result));
+        return result;
     }
 
-    public static String getLatestTag() {
-        return latestTag;
+    /** Read-only snapshot; this never performs network I/O. Null means no completed recommendation. */
+    public @Nullable ReleaseManifest.Release getAvailableUpdate() {
+        return availableUpdate;
     }
 
+    private void refresh(CompletableFuture<ReleaseManifest.Release> result) {
+        try {
+            ReleaseManifest.Release release = fetch().findUpdate(currentVersion, versionIdentifier);
+            synchronized (this) {
+                if (closed) return;
+                ReleaseManifest.Release previous = availableUpdate;
+                availableUpdate = release;
+                if (release != null && (previous == null || !previous.tag.equals(release.tag))) {
+                    LOG.warn(
+                        "New {} release of AE2 Web Integration: {} at {}",
+                        release.channel == ReleaseManifest.Channel.STABLE ? "stable" : "prerelease",
+                        release.tag,
+                        release.releaseUrl);
+                }
+                pending = null;
+                scheduled = executor.schedule(this::checkForUpdates, 5, TimeUnit.HOURS);
+                result.complete(release);
+            }
+        } catch (Exception e) {
+            synchronized (this) {
+                if (closed) return;
+                LOG.debug("Could not check AE2 Web Integration releases", e);
+                pending = null;
+                scheduled = executor.schedule(this::checkForUpdates, 5, TimeUnit.MINUTES);
+                result.completeExceptionally(e);
+            }
+        }
+    }
+
+    private ReleaseManifest fetch() throws IOException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+        HttpURLConnection request = (HttpURLConnection) feedUrl.openConnection();
+        request.setConnectTimeout(5000);
+        request.setReadTimeout(5000);
+        request.setRequestProperty("User-Agent", "AE2-Web-Integration");
+        request.setRequestProperty("Accept", "application/json");
+        synchronized (this) {
+            if (closed) throw new IOException("Version checker stopped");
+        }
+        try {
+            if (request.getResponseCode() != 200)
+                throw new IOException("Release feed HTTP status: " + request.getResponseCode());
+            if (request.getContentLengthLong() > MAX_RESPONSE_BYTES) throw new IOException("Release feed is too large");
+            try (InputStream input = request.getInputStream();
+                ByteArrayOutputStream body = new ByteArrayOutputStream()) {
+                byte[] bytes = new byte[4096];
+                int length;
+                while ((length = input.read(bytes)) != -1) {
+                    if (System.nanoTime() - deadline >= 0) throw new IOException("Release feed timed out");
+                    if (body.size() + length > MAX_RESPONSE_BYTES) throw new IOException("Release feed is too large");
+                    body.write(bytes, 0, length);
+                }
+                return ReleaseManifest.parse(new String(body.toByteArray(), StandardCharsets.UTF_8), minecraftVersion);
+            }
+        } finally {
+            request.disconnect();
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        closed = true;
+        availableUpdate = null;
+        if (pending != null) pending.cancel(false);
+        // HttpURLConnection.disconnect can block behind an in-progress read. The worker owns
+        // closing its connection; finite I/O timeouts bound cleanup without stalling server stop.
+        executor.shutdownNow();
+    }
 }

--- a/src/test/java/pl/kuba6000/ae2webintegration/core/UpdateNotifierTest.java
+++ b/src/test/java/pl/kuba6000/ae2webintegration/core/UpdateNotifierTest.java
@@ -1,19 +1,87 @@
 package pl.kuba6000.ae2webintegration.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
+import com.sun.net.httpserver.HttpServer;
+
+import pl.kuba6000.ae2webintegration.core.api.IConfigValue;
 import pl.kuba6000.ae2webintegration.core.api.IPlayerMessenger;
 import pl.kuba6000.ae2webintegration.core.api.PlayerIdentity;
+import pl.kuba6000.ae2webintegration.core.config.ConfigBootstrap;
+import pl.kuba6000.ae2webintegration.core.utils.VersionChecker;
 
 class UpdateNotifierTest {
 
     private static final PlayerIdentity PLAYER = new PlayerIdentity(
         UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
         "Player");
+
+    @Test
+    void notifiesAuthorizedPlayersFromCachedReleaseAndHonorsOptOutAndStop() throws Exception {
+        String releaseUrl = "https://github.com/kuba6000/AE2-Web-Integration/releases/tag/1.1.0-forge-1.7.10";
+        String feed = "{\"version\":\"1.7.10\",\"releases\":{\"prerelease\":null,\"stable\":{"
+            + "\"newest\":\"1.1.0\",\"timestamp\":1786902605,\"github_release_tag\":\"1.1.0-forge-1.7.10\","
+            + "\"github_release_url\":\""
+            + releaseUrl
+            + "\",\"github_release_download_url\":\"https://github.com/kuba6000/AE2-Web-Integration/releases/download/1.1.0-forge-1.7.10/mod.jar\"}}}";
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            byte[] bytes = feed.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody()
+                .write(bytes);
+            exchange.close();
+        });
+        server.start();
+        IConfigValue<Boolean> oldConfig = ConfigBootstrap.checkForUpdatesValue;
+        // Wire a real local feed into the lifecycle owner without a production test-only setter.
+        Field activeChecker = CoreEngine.class.getDeclaredField("versionChecker");
+        activeChecker.setAccessible(true);
+        Object previous = activeChecker.get(null);
+        try (VersionChecker checker = new VersionChecker(
+            new URL(
+                "http://127.0.0.1:" + server.getAddress()
+                    .getPort() + "/"),
+            "1.0.0-forge-1.7.10",
+            "-forge-1.7.10")) {
+            activeChecker.set(null, checker);
+            ConfigBootstrap.checkForUpdatesValue = () -> true;
+            RecordingMessenger messenger = new RecordingMessenger();
+            UpdateNotifier.onPlayerLoggedIn(messenger, PLAYER, true);
+            assertEquals(0, messenger.sentMessages);
+            checker.checkForUpdates()
+                .get(5, TimeUnit.SECONDS);
+            UpdateNotifier.onPlayerLoggedIn(messenger, PLAYER, false);
+            assertEquals(0, messenger.sentMessages);
+            UpdateNotifier.onPlayerLoggedIn(messenger, PLAYER, true);
+            assertEquals(1, messenger.sentMessages);
+            assertTrue(messenger.lastMessage.contains("1.1.0-forge-1.7.10"));
+            assertTrue(messenger.lastMessage.contains(releaseUrl));
+            ConfigBootstrap.checkForUpdatesValue = () -> false;
+            UpdateNotifier.onPlayerLoggedIn(messenger, PLAYER, true);
+            assertEquals(1, messenger.sentMessages);
+            CoreEngine.onServerStopping();
+            assertNull(CoreEngine.getAvailableUpdate());
+            assertTrue(
+                checker.checkForUpdates()
+                    .isCancelled());
+        } finally {
+            activeChecker.set(null, previous);
+            ConfigBootstrap.checkForUpdatesValue = oldConfig;
+            server.stop(0);
+        }
+    }
 
     @Test
     void onPlayerLoggedInDoesNotNotifyPlayersWithoutAdminNoticePermission() {
@@ -27,10 +95,12 @@ class UpdateNotifierTest {
     private static class RecordingMessenger implements IPlayerMessenger {
 
         int sentMessages;
+        String lastMessage;
 
         @Override
         public void sendMessage(PlayerIdentity player, String message) {
             sentMessages++;
+            lastMessage = message;
         }
     }
 

--- a/src/test/java/pl/kuba6000/ae2webintegration/core/utils/ReleaseManifestTest.java
+++ b/src/test/java/pl/kuba6000/ae2webintegration/core/utils/ReleaseManifestTest.java
@@ -1,0 +1,104 @@
+package pl.kuba6000.ae2webintegration.core.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ReleaseManifestTest {
+
+    @Test
+    void handlesAllAdaptersOverridesAndDevelopmentBuildsConservatively() {
+        for (String target : new String[] { "1.7.10", "1.12.2", "1.20.1", "1.21.1" }) {
+            String loader = target.equals("1.21.1") ? "neoforge" : "forge";
+            String identifier = "-" + loader + "-" + target;
+            ReleaseManifest manifest = ReleaseManifest.parse(
+                feed("1.1.0", "1.2.0").replace("1.7.10", target)
+                    .replace("forge", loader),
+                target);
+            assertEquals("1.1.0", manifest.findUpdate("1.0.9" + identifier, identifier).version);
+            assertEquals("1.1.0", manifest.findUpdate("1.0.9", identifier).version);
+            assertEquals("1.2.0", manifest.findUpdate("0.2.1-alpha" + identifier + "-pre", identifier).version);
+            assertEquals("1.1.0", manifest.findUpdate("1.0.9" + identifier + "-19-gabcdef.dirty", identifier).version);
+            assertNull(manifest.findUpdate("1.1.0" + identifier + "-19-gabcdef.dirty", identifier));
+            assertNull(manifest.findUpdate("NO-GIT-TAG-SET", identifier));
+        }
+        ReleaseManifest manifest = ReleaseManifest.parse(feed("1.1.0", "1.1.0"), "1.7.10");
+        assertNull(manifest.findUpdate("1.1.0-forge-pre-1.7.10-1-7-10+28363aee73-dirty", "-forge-1.7.10"));
+        assertNull(manifest.findUpdate("0.0.1-neoforge-1.21.1", "-forge-1.7.10"));
+    }
+
+    @Test
+    void rejectsInvalidMetadataAndSupportsEmptyChannels() {
+        assertNull(
+            ReleaseManifest.parse(feed(null, null), "1.7.10")
+                .findUpdate("1.0.0", "-forge-1.7.10"));
+        for (String invalid : new String[] { feed("1.1.0", null).replace("1786902605", "\"1786902605\""),
+            feed("1.1.0", null).replace("1786902605", "1786902605.5"),
+            feed("1.1.0", null).replace("https://github.com", "javascript:evil"),
+            feed("1.1.0", null).replace("\"version\":\"1.7.10\"", "\"version\":\"1.12.2\""), feed("garbage", null),
+            feed("1.1.0-alpha.1", null), feed("1.1.0", "1.2.0-beta..2"), feed("1.1.0", "1.2.0-beta.1+build..1") })
+            assertThrows(RuntimeException.class, () -> ReleaseManifest.parse(invalid, "1.7.10"));
+    }
+
+    @Test
+    void treatsBuildMetadataAsUnorderedAndChecksWholePlatformTarget() {
+        ReleaseManifest manifest = ReleaseManifest.parse(feed("1.2.0+build.1", "1.3.0-beta.2+build.3"), "1.7.10");
+        assertEquals("1.2.0+build.1", manifest.findUpdate("1.1.0+build.9", "-forge-1.7.10").version);
+        assertNull(manifest.findUpdate("1.2.0+build.9", "-forge-1.7.10"));
+        assertNull(manifest.findUpdate("1.0.0-forge-1.7.100", "-forge-1.7.10"));
+        assertEquals(
+            "1.3.0-beta.2+build.3",
+            manifest.findUpdate("1.2.0-forge-1.7.10-pre-19-gabcdef", "-forge-1.7.10").version);
+    }
+
+    @Test
+    void prereleasesFollowBothChannelsWithoutDowngradesOrInventedOrdering() {
+        String identifier = "-forge-1.7.10";
+        ReleaseManifest manifest = ReleaseManifest.parse(feed("1.1.0", "1.2.0-beta.2"), "1.7.10");
+        assertEquals("1.2.0-beta.2", manifest.findUpdate("1.1.0-forge-pre-1.7.10", identifier).version);
+        assertEquals("1.2.0-beta.2", manifest.findUpdate("1.2.0-beta.1-forge-1.7.10", identifier).version);
+        assertNull(manifest.findUpdate("1.2.0-beta.10-forge-1.7.10", identifier));
+        manifest = ReleaseManifest.parse(feed("1.1.0", "1.1.0"), "1.7.10");
+        assertEquals(ReleaseManifest.Channel.STABLE, manifest.findUpdate("1.1.0-forge-pre-1.7.10", identifier).channel);
+        assertNull(manifest.findUpdate("1.2.0-forge-pre-1.7.10", identifier));
+        manifest = ReleaseManifest.parse(feed("1.0.2", "1.1.0"), "1.7.10");
+        assertNull(manifest.findUpdate("1.1.0-other-feature-forge-pre-1.7.10", identifier));
+        assertEquals(
+            "1.1.0",
+            manifest.findUpdate("1.0.3-GTNH-Native-Fluids-Support-forge-pre-1.7.10", identifier).version);
+    }
+
+    @Test
+    void stableInstallOnlySelectsNewerStableAndPreservesMetadata() {
+        ReleaseManifest manifest = ReleaseManifest.parse(feed("1.0.2", "1.1.0"), "1.7.10");
+        ReleaseManifest.Release update = manifest.findUpdate("1.0.1-forge-1.7.10", "-forge-1.7.10");
+        assertNotNull(update);
+        assertEquals("1.0.2", update.version);
+        assertEquals(ReleaseManifest.Channel.STABLE, update.channel);
+        assertEquals(1786902605L, update.timestamp);
+        assertTrue(update.releaseUrl.endsWith("/1.0.2-forge-1.7.10"));
+        assertTrue(update.downloadUrl.endsWith("/mod.jar"));
+        assertNull(manifest.findUpdate("1.0.2-forge-1.7.10", "-forge-1.7.10"));
+        assertNull(manifest.findUpdate("1.0.3-forge-1.7.10", "-forge-1.7.10"));
+    }
+
+    static String feed(String stable, String pre) {
+        return "{\"version\":\"1.7.10\",\"releases\":{\"stable\":" + release(stable, false)
+            + ",\"prerelease\":"
+            + release(pre, true)
+            + "}}";
+    }
+
+    static String release(String version, boolean pre) {
+        if (version == null) return "null";
+        String tag = version + (pre ? "-forge-pre-1.7.10" : "-forge-1.7.10");
+        return "{\"newest\":\"" + version
+            + "\",\"timestamp\":1786902605,\"github_release_tag\":\""
+            + tag
+            + "\",\"github_release_url\":\"https://github.com/kuba6000/AE2-Web-Integration/releases/tag/"
+            + tag
+            + "\",\"github_release_download_url\":\"https://github.com/kuba6000/AE2-Web-Integration/releases/download/"
+            + tag
+            + "/mod.jar\"}";
+    }
+}

--- a/src/test/java/pl/kuba6000/ae2webintegration/core/utils/VersionCheckerTest.java
+++ b/src/test/java/pl/kuba6000/ae2webintegration/core/utils/VersionCheckerTest.java
@@ -1,0 +1,173 @@
+package pl.kuba6000.ae2webintegration.core.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpServer;
+
+class VersionCheckerTest {
+
+    @Test
+    void refreshesExistingUpdateAndRetainsLastGoodResultAcrossFailures() throws Exception {
+        AtomicReference<String> body = new AtomicReference<>(ReleaseManifestTest.feed("1.1.0", null));
+        AtomicInteger status = new AtomicInteger(200);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            byte[] bytes = body.get()
+                .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(status.get(), bytes.length);
+            exchange.getResponseBody()
+                .write(bytes);
+            exchange.close();
+        });
+        server.start();
+        try (VersionChecker checker = new VersionChecker(
+            new URL(
+                "http://127.0.0.1:" + server.getAddress()
+                    .getPort() + "/"),
+            "1.0.0-forge-1.7.10",
+            "-forge-1.7.10")) {
+            assertEquals(
+                "1.1.0",
+                checker.checkForUpdates()
+                    .get(5, TimeUnit.SECONDS).version);
+            status.set(503);
+            assertThrows(
+                ExecutionException.class,
+                () -> checker.checkForUpdates()
+                    .get(5, TimeUnit.SECONDS));
+            assertEquals("1.1.0", checker.getAvailableUpdate().version);
+            status.set(200);
+            body.set("not json");
+            assertThrows(
+                ExecutionException.class,
+                () -> checker.checkForUpdates()
+                    .get(5, TimeUnit.SECONDS));
+            body.set(new String(new char[70_000]).replace('\0', 'x'));
+            assertThrows(
+                ExecutionException.class,
+                () -> checker.checkForUpdates()
+                    .get(5, TimeUnit.SECONDS));
+            body.set(ReleaseManifestTest.feed("1.2.0", null));
+            assertEquals(
+                "1.2.0",
+                checker.checkForUpdates()
+                    .get(5, TimeUnit.SECONDS).version);
+            body.set(ReleaseManifestTest.feed(null, null));
+            assertNull(
+                checker.checkForUpdates()
+                    .get(5, TimeUnit.SECONDS));
+            assertNull(checker.getAvailableUpdate());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void stoppingDuringRequestReturnsImmediatelyAndCannotPublishLateResult() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch respond = new CountDownLatch(1);
+        server.createContext("/", exchange -> {
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody()
+                .write(' ');
+            exchange.getResponseBody()
+                .flush();
+            entered.countDown();
+            try {
+                respond.await(5, TimeUnit.SECONDS);
+                byte[] bytes = ReleaseManifestTest.feed("1.1.0", null)
+                    .getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseBody()
+                    .write(bytes);
+            } catch (InterruptedException e) {
+                Thread.currentThread()
+                    .interrupt();
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+        VersionChecker checker = new VersionChecker(
+            new URL(
+                "http://127.0.0.1:" + server.getAddress()
+                    .getPort() + "/"),
+            "1.0.0-forge-1.7.10",
+            "-forge-1.7.10");
+        try {
+            CompletableFuture<ReleaseManifest.Release> result = checker.checkForUpdates();
+            assertTrue(entered.await(5, TimeUnit.SECONDS));
+            CompletableFuture.runAsync(checker::close)
+                .get(1, TimeUnit.SECONDS);
+            assertTrue(result.isCancelled());
+            respond.countDown();
+            assertNull(checker.getAvailableUpdate());
+            assertTrue(
+                checker.checkForUpdates()
+                    .isCancelled());
+        } finally {
+            respond.countDown();
+            checker.close();
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void fetchesOffCallerThreadCoalescesAndCachesCompletedResult() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch respond = new CountDownLatch(1);
+        AtomicReference<String> requestedPath = new AtomicReference<>();
+        server.createContext("/", exchange -> {
+            requestedPath.set(
+                exchange.getRequestURI()
+                    .getPath());
+            entered.countDown();
+            try {
+                if (!respond.await(5, TimeUnit.SECONDS)) throw new AssertionError("Test response not released");
+                byte[] body = ReleaseManifestTest.feed("1.1.0", null)
+                    .getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, body.length);
+                exchange.getResponseBody()
+                    .write(body);
+            } catch (InterruptedException e) {
+                Thread.currentThread()
+                    .interrupt();
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+        try (VersionChecker checker = new VersionChecker(
+            new URL(
+                "http://127.0.0.1:" + server.getAddress()
+                    .getPort() + "/"),
+            "1.0.0-forge-1.7.10",
+            "-forge-1.7.10")) {
+            CompletableFuture<ReleaseManifest.Release> result = checker.checkForUpdates();
+            assertTrue(entered.await(5, TimeUnit.SECONDS));
+            assertFalse(result.isDone());
+            assertNull(checker.getAvailableUpdate());
+            assertSame(result, checker.checkForUpdates());
+            respond.countDown();
+            assertEquals("1.1.0", result.get(5, TimeUnit.SECONDS).version);
+            assertSame(result.get(), checker.getAvailableUpdate());
+            assertEquals("/1.7.10.json", requestedPath.get());
+        } finally {
+            respond.countDown();
+            server.stop(0);
+        }
+    }
+}


### PR DESCRIPTION
Replace tag-based update detection with per-Minecraft release manifests on the `version` branch. Stable installations receive only stable updates; prerelease installations can also move to newer prereleases or stable releases. Run checks in the background and use cached results for update notifications. Automatically update the manifests after successful release builds using the existing bot account.
