### PR TITLE
Implement stable CPU IDs on 1.7.10

### DIFF
--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/legacy/LegacyItemIdentity.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/legacy/LegacyItemIdentity.java
@@ -26,7 +26,7 @@ import appeng.api.storage.data.IAEStack;
 import appeng.util.item.AEFluidStack;
 import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.registry.GameData;
-import pl.kuba6000.ae2webintegration.core.identity.StableItemKey;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 
 /** Canonical native identity only; amounts, crafting flags and display data never enter these bytes. */
@@ -37,7 +37,7 @@ public final class LegacyItemIdentity {
 
     private LegacyItemIdentity() {}
 
-    public static @NotNull StableItemKey encode(@NotNull IAEStack<?> stack) {
+    public static @NotNull StableKey encode(@NotNull IAEStack<?> stack) {
         if (stack instanceof AEItemStack) {
             AEItemStack item = (AEItemStack) stack;
             return encode(
@@ -69,16 +69,16 @@ public final class LegacyItemIdentity {
         return (IAEKey) result;
     }
 
-    private static StableItemKey encode(String kind, @Nullable String registry, int metadata,
+    private static StableKey encode(String kind, @Nullable String registry, int metadata,
         @Nullable NBTTagCompound secondary) {
         if (registry == null || registry.isEmpty()) {
             throw new UnsupportedOperationException("Resource has no registered identity");
         }
-        return StableItemKey.create(sink -> {
+        return StableKey.create(sink -> {
             DataOutputStream output = new DataOutputStream(Funnels.asOutputStream(sink));
             try {
-                StableItemKey.writeText(sink, kind);
-                StableItemKey.writeText(sink, registry);
+                StableKey.writeText(sink, kind);
+                StableKey.writeText(sink, registry);
                 output.writeInt(metadata);
                 output.writeByte(secondary == null ? 0 : 1);
                 if (secondary != null) new Tags(output, sink, "fluid".equals(kind)).write(secondary, 0, true, false);
@@ -141,7 +141,7 @@ public final class LegacyItemIdentity {
                     output.write(byteArray);
                     break;
                 case 8:
-                    StableItemKey.writeText(sink, ((NBTTagString) tag).func_150285_a_());
+                    StableKey.writeText(sink, ((NBTTagString) tag).func_150285_a_());
                     break;
                 case 9:
                     NBTTagList list = (NBTTagList) tag;
@@ -184,7 +184,7 @@ public final class LegacyItemIdentity {
                     Arrays.sort(names);
                     output.writeInt(names.length);
                     for (String name : names) {
-                        StableItemKey.writeText(sink, name);
+                        StableKey.writeText(sink, name);
                         write(compound.getTag(name), depth + 1, true, owned);
                     }
                     break;

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -3,6 +3,7 @@ package pl.kuba6000.ae2webintegration.ae2interface.mixins.AE2.implementations;
 import net.minecraft.world.World;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -14,6 +15,8 @@ import appeng.api.storage.data.IItemList;
 import appeng.api.util.WorldCoord;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import appeng.util.item.IAEStackList;
+import pl.kuba6000.ae2webintegration.core.identity.CpuIdentity;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.ICraftingCPUCluster;
@@ -35,9 +38,15 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     @Unique
     private int web$internalID = -1;
 
+    @Unique
+    private @Nullable StableKey web$stableKey;
+
     @Override
     public @NotNull String web$getId() {
-        return "ae2:" + getWorld().provider.dimensionId + ":" + min.x + ":" + min.y + ":" + min.z;
+        if (web$stableKey == null) {
+            web$stableKey = CpuIdentity.ae2(Integer.toString(getWorld().provider.dimensionId), min.x, min.y, min.z);
+        }
+        return web$stableKey.toString();
     }
 
     @Override

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -41,7 +41,7 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     private @Nullable StableKey web$stableKey;
 
     @Override
-    public @NotNull StableKey web$getId() {
+    public @NotNull StableKey web$getKey() {
         if (web$stableKey == null) {
             web$stableKey = StableKey.create(
                 sink -> {

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -41,7 +41,7 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     private @Nullable StableKey web$stableKey;
 
     @Override
-    public @NotNull String web$getId() {
+    public @NotNull StableKey web$getId() {
         if (web$stableKey == null) {
             web$stableKey = StableKey.create(sink -> {
                 StableKey.writeText(sink, "cpu:ae2");
@@ -51,7 +51,7 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
                     .putInt(min.z);
             });
         }
-        return web$stableKey.toString();
+        return web$stableKey;
     }
 
     @Override

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -43,13 +43,13 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     @Override
     public @NotNull StableKey web$getId() {
         if (web$stableKey == null) {
-            web$stableKey = StableKey.create(sink -> {
-                StableKey.writeText(sink, "cpu:ae2");
-                StableKey.writeText(sink, Integer.toString(getWorld().provider.dimensionId));
-                sink.putInt(min.x)
-                    .putInt(min.y)
-                    .putInt(min.z);
-            });
+            web$stableKey = StableKey.create(
+                sink -> {
+                    sink.putInt(getWorld().provider.dimensionId)
+                        .putInt(min.x)
+                        .putInt(min.y)
+                        .putInt(min.z);
+                });
         }
         return web$stableKey;
     }

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -1,5 +1,9 @@
 package pl.kuba6000.ae2webintegration.ae2interface.mixins.AE2.implementations;
 
+import net.minecraft.world.World;
+
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -7,6 +11,7 @@ import org.spongepowered.asm.mixin.Unique;
 import appeng.api.networking.crafting.CraftingItemList;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
+import appeng.api.util.WorldCoord;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import appeng.util.item.IAEStackList;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
@@ -18,10 +23,22 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IStackList;
 public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
 
     @Shadow
+    @Final
+    protected WorldCoord min;
+
+    @Shadow
+    protected abstract World getWorld();
+
+    @Shadow
     private IItemList<IAEStack<?>> waitingFor;
 
     @Unique
     private int web$internalID = -1;
+
+    @Override
+    public @NotNull String web$getId() {
+        return "ae2:" + getWorld().provider.dimensionId + ":" + min.x + ":" + min.y + ":" + min.z;
+    }
 
     @Override
     public void web$setInternalID(int id) {

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -15,7 +15,6 @@ import appeng.api.storage.data.IItemList;
 import appeng.api.util.WorldCoord;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import appeng.util.item.IAEStackList;
-import pl.kuba6000.ae2webintegration.core.identity.CpuIdentity;
 import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
@@ -44,7 +43,13 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     @Override
     public @NotNull String web$getId() {
         if (web$stableKey == null) {
-            web$stableKey = CpuIdentity.ae2(Integer.toString(getWorld().provider.dimensionId), min.x, min.y, min.z);
+            web$stableKey = StableKey.create(sink -> {
+                StableKey.writeText(sink, "cpu:ae2");
+                StableKey.writeText(sink, Integer.toString(getWorld().provider.dimensionId));
+                sink.putInt(min.x)
+                    .putInt(min.y)
+                    .putInt(min.z);
+            });
         }
         return web$stableKey.toString();
     }

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEStackMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEStackMixin.java
@@ -11,7 +11,7 @@ import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IAEStackType;
 import cpw.mods.fml.common.registry.GameData;
 import pl.kuba6000.ae2webintegration.ae2interface.legacy.LegacyItemIdentity;
-import pl.kuba6000.ae2webintegration.core.identity.StableItemKey;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGrid;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
@@ -20,7 +20,7 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 public interface AEStackMixin extends IAEStack, IAEGenericStack, IAEKey {
 
     @Override
-    default @NotNull StableItemKey web$getStableKey() throws IOException {
+    default @NotNull StableKey web$getStableKey() throws IOException {
         return LegacyItemIdentity.encode(this);
     }
 

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEStackMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEStackMixin.java
@@ -1,7 +1,5 @@
 package pl.kuba6000.ae2webintegration.ae2interface.mixins.AE2.implementations;
 
-import java.io.IOException;
-
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 
@@ -20,12 +18,12 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 public interface AEStackMixin extends IAEStack, IAEGenericStack, IAEKey {
 
     @Override
-    default @NotNull StableKey web$getStableKey() throws IOException {
+    default @NotNull StableKey web$getKey() {
         return LegacyItemIdentity.encode(this);
     }
 
     @Override
-    default IAEKey web$copyIdentity() throws IOException {
+    default IAEKey web$copyIdentity() {
         return LegacyItemIdentity.copy(this);
     }
 


### PR DESCRIPTION
Implement the native CPU identity contract from #71 on Minecraft 1.7.10, allowing equally named CPUs to remain separate targets on the website.

The existing CPU mixin hashes four native integers: dimension ID and minimum X/Y/Z. It retains the StableKey lazily on the CPU object. No type prefix, new registry, persistence hooks or NBT accessors are added.

Use web$getKey() for both resources and CPUs, returning the shared StableKey. Remove checked IOException from native identity access/copy; item identity encoding is unchanged. Pin core to f8c515d37058eb8172b50a3ad440cd51572216f2.

Validation: full Gradle build and formatting passed. Earlier isolated server checks covered the native CPU shadows; the final raw-input adjustment was verified by compilation/source review. No new full gameplay restart test was performed.

Depends on #71. After its squash merge, update the core pin to the resulting core commit before merging this PR.
