### PR TITLE
Implement stable CPU IDs on 1.12.2

### DIFF
--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/legacy/LegacyItemIdentity.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/legacy/LegacyItemIdentity.java
@@ -24,7 +24,7 @@ import com.google.common.hash.PrimitiveSink;
 import appeng.api.storage.data.IAEStack;
 import appeng.fluids.util.AEFluidStack;
 import appeng.util.item.AEItemStack;
-import pl.kuba6000.ae2webintegration.core.identity.StableItemKey;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 
 /** Canonical native identity only; amounts, crafting flags and display data never enter these bytes. */
@@ -35,7 +35,7 @@ public final class LegacyItemIdentity {
 
     private LegacyItemIdentity() {}
 
-    public static @NotNull StableItemKey encode(@NotNull IAEStack<?> stack) {
+    public static @NotNull StableKey encode(@NotNull IAEStack<?> stack) {
         if (stack instanceof AEItemStack) {
             AEItemStack item = (AEItemStack) stack;
             NBTTagCompound identity = item.getDefinition()
@@ -80,16 +80,16 @@ public final class LegacyItemIdentity {
         return (IAEKey) result;
     }
 
-    private static StableItemKey encode(String kind, @Nullable String registry, int metadata,
+    private static StableKey encode(String kind, @Nullable String registry, int metadata,
         @Nullable NBTTagCompound secondary) {
         if (registry == null || registry.isEmpty()) {
             throw new UnsupportedOperationException("Resource has no registered identity");
         }
-        return StableItemKey.create(sink -> {
+        return StableKey.create(sink -> {
             DataOutputStream output = new DataOutputStream(Funnels.asOutputStream(sink));
             try {
-                StableItemKey.writeText(sink, kind);
-                StableItemKey.writeText(sink, registry);
+                StableKey.writeText(sink, kind);
+                StableKey.writeText(sink, registry);
                 output.writeInt(metadata);
                 output.writeByte(secondary == null ? 0 : 1);
                 if (secondary != null) new Tags(output, sink, "fluid".equals(kind)).write(secondary, 0, true);
@@ -152,7 +152,7 @@ public final class LegacyItemIdentity {
                     output.write(byteArray);
                     break;
                 case 8:
-                    StableItemKey.writeText(sink, ((NBTTagString) tag).getString());
+                    StableKey.writeText(sink, ((NBTTagString) tag).getString());
                     break;
                 case 9:
                     NBTTagList list = (NBTTagList) tag;
@@ -180,7 +180,7 @@ public final class LegacyItemIdentity {
                     Arrays.sort(names);
                     output.writeInt(names.length);
                     for (String name : names) {
-                        StableItemKey.writeText(sink, name);
+                        StableKey.writeText(sink, name);
                         write(compound.getTag(name), depth + 1, true);
                     }
                     break;

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -3,6 +3,10 @@ package pl.kuba6000.ae2webintegration.ae2interface.mixins.AE2.implementations;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import net.minecraft.world.World;
+
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -12,6 +16,7 @@ import appeng.api.networking.crafting.CraftingItemList;
 import appeng.api.storage.channels.IItemStorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+import appeng.api.util.WorldCoord;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
@@ -20,6 +25,15 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IStackList;
 
 @Mixin(value = CraftingCPUCluster.class, remap = false)
 public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
+
+    @Shadow
+    @Final
+    private WorldCoord min;
+
+    @Shadow
+    private World getWorld() {
+        throw new IllegalStateException("Mixin failed to apply");
+    }
 
     @Shadow
     private IItemList<IAEItemStack> waitingFor;
@@ -35,6 +49,11 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
 
     @Unique
     private Method web$getUsedStorageMethod = null;
+
+    @Override
+    public @NotNull String web$getId() {
+        return "ae2:" + getWorld().provider.getDimension() + ":" + min.x + ":" + min.y + ":" + min.z;
+    }
 
     @Override
     public void web$setInternalID(int id) {

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -19,7 +19,6 @@ import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.WorldCoord;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
-import pl.kuba6000.ae2webintegration.core.identity.CpuIdentity;
 import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
@@ -59,7 +58,13 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     @Override
     public @NotNull String web$getId() {
         if (web$stableKey == null) {
-            web$stableKey = CpuIdentity.ae2(Integer.toString(getWorld().provider.getDimension()), min.x, min.y, min.z);
+            web$stableKey = StableKey.create(sink -> {
+                StableKey.writeText(sink, "cpu:ae2");
+                StableKey.writeText(sink, Integer.toString(getWorld().provider.getDimension()));
+                sink.putInt(min.x)
+                    .putInt(min.y)
+                    .putInt(min.z);
+            });
         }
         return web$stableKey.toString();
     }

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import net.minecraft.world.World;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -18,6 +19,8 @@ import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.WorldCoord;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
+import pl.kuba6000.ae2webintegration.core.identity.CpuIdentity;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.ICraftingCPUCluster;
@@ -50,9 +53,15 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     @Unique
     private Method web$getUsedStorageMethod = null;
 
+    @Unique
+    private @Nullable StableKey web$stableKey;
+
     @Override
     public @NotNull String web$getId() {
-        return "ae2:" + getWorld().provider.getDimension() + ":" + min.x + ":" + min.y + ":" + min.z;
+        if (web$stableKey == null) {
+            web$stableKey = CpuIdentity.ae2(Integer.toString(getWorld().provider.getDimension()), min.x, min.y, min.z);
+        }
+        return web$stableKey.toString();
     }
 
     @Override

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -58,13 +58,13 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     @Override
     public @NotNull StableKey web$getId() {
         if (web$stableKey == null) {
-            web$stableKey = StableKey.create(sink -> {
-                StableKey.writeText(sink, "cpu:ae2");
-                StableKey.writeText(sink, Integer.toString(getWorld().provider.getDimension()));
-                sink.putInt(min.x)
-                    .putInt(min.y)
-                    .putInt(min.z);
-            });
+            web$stableKey = StableKey.create(
+                sink -> {
+                    sink.putInt(getWorld().provider.getDimension())
+                        .putInt(min.x)
+                        .putInt(min.y)
+                        .putInt(min.z);
+                });
         }
         return web$stableKey;
     }

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -56,7 +56,7 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     private @Nullable StableKey web$stableKey;
 
     @Override
-    public @NotNull StableKey web$getId() {
+    public @NotNull StableKey web$getKey() {
         if (web$stableKey == null) {
             web$stableKey = StableKey.create(
                 sink -> {

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -56,7 +56,7 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     private @Nullable StableKey web$stableKey;
 
     @Override
-    public @NotNull String web$getId() {
+    public @NotNull StableKey web$getId() {
         if (web$stableKey == null) {
             web$stableKey = StableKey.create(sink -> {
                 StableKey.writeText(sink, "cpu:ae2");
@@ -66,7 +66,7 @@ public abstract class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
                     .putInt(min.z);
             });
         }
-        return web$stableKey.toString();
+        return web$stableKey;
     }
 
     @Override

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEFluidStackMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEFluidStackMixin.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.Mixin;
 
 import appeng.api.storage.data.IAEFluidStack;
 import pl.kuba6000.ae2webintegration.ae2interface.legacy.LegacyItemIdentity;
-import pl.kuba6000.ae2webintegration.core.identity.StableItemKey;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGrid;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
@@ -16,7 +16,7 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 public interface AEFluidStackMixin extends IAEFluidStack, IAEKey, IAEGenericStack {
 
     @Override
-    default @NotNull StableItemKey web$getStableKey() throws IOException {
+    default @NotNull StableKey web$getStableKey() throws IOException {
         return LegacyItemIdentity.encode(this);
     }
 

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEFluidStackMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEFluidStackMixin.java
@@ -1,7 +1,5 @@
 package pl.kuba6000.ae2webintegration.ae2interface.mixins.AE2.implementations;
 
-import java.io.IOException;
-
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 
@@ -16,12 +14,12 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 public interface AEFluidStackMixin extends IAEFluidStack, IAEKey, IAEGenericStack {
 
     @Override
-    default @NotNull StableKey web$getStableKey() throws IOException {
+    default @NotNull StableKey web$getKey() {
         return LegacyItemIdentity.encode(this);
     }
 
     @Override
-    default IAEKey web$copyIdentity() throws IOException {
+    default IAEKey web$copyIdentity() {
         return LegacyItemIdentity.copy(this);
     }
 

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEItemStackMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEItemStackMixin.java
@@ -1,7 +1,5 @@
 package pl.kuba6000.ae2webintegration.ae2interface.mixins.AE2.implementations;
 
-import java.io.IOException;
-
 import net.minecraft.item.Item;
 
 import org.jetbrains.annotations.NotNull;
@@ -19,12 +17,12 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 public interface AEItemStackMixin extends IAEItemStack, IAEKey, IAEGenericStack {
 
     @Override
-    default @NotNull StableKey web$getStableKey() throws IOException {
+    default @NotNull StableKey web$getKey() {
         return LegacyItemIdentity.encode(this);
     }
 
     @Override
-    default IAEKey web$copyIdentity() throws IOException {
+    default IAEKey web$copyIdentity() {
         return LegacyItemIdentity.copy(this);
     }
 

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEItemStackMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEItemStackMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.Shadow;
 
 import appeng.api.storage.data.IAEItemStack;
 import pl.kuba6000.ae2webintegration.ae2interface.legacy.LegacyItemIdentity;
-import pl.kuba6000.ae2webintegration.core.identity.StableItemKey;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGrid;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
@@ -19,7 +19,7 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 public interface AEItemStackMixin extends IAEItemStack, IAEKey, IAEGenericStack {
 
     @Override
-    default @NotNull StableItemKey web$getStableKey() throws IOException {
+    default @NotNull StableKey web$getStableKey() throws IOException {
         return LegacyItemIdentity.encode(this);
     }
 


### PR DESCRIPTION
Implement the native CPU identity contract from #71 on Minecraft 1.12.2, allowing equally named CPUs to remain separate targets on the website.

The existing CPU mixin hashes four native integers: dimension ID and minimum X/Y/Z. It retains the StableKey lazily on the CPU object. No type prefix, new registry, persistence hooks or NBT accessors are added.

Use web$getKey() for both resources and CPUs, returning the shared StableKey. Remove checked IOException from native identity access/copy; item identity encoding is unchanged. Pin core to f8c515d37058eb8172b50a3ad440cd51572216f2.

Validation: full Gradle build and formatting passed. Earlier isolated server checks covered the native CPU shadows; the final raw-input adjustment was verified by compilation/source review. No new full gameplay restart test was performed.

Depends on #71. After its squash merge, update the core pin to the resulting core commit before merging this PR.
