### PR TITLE
Implement stable CPU IDs on 1.20.1

### DIFF
--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/implementations/CanonicalNbt.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/implementations/CanonicalNbt.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.google.common.hash.PrimitiveSink;
 
-import pl.kuba6000.ae2webintegration.core.identity.StableItemKey;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 
 /** Streams typed native data without allocating a complete canonical byte representation. */
 final class CanonicalNbt {
@@ -54,7 +54,7 @@ final class CanonicalNbt {
                 writeLong(sink, Double.doubleToLongBits(((NumericTag) tag).getAsDouble()));
                 break;
             case Tag.TAG_STRING:
-                StableItemKey.writeText(sink, tag.getAsString());
+                StableKey.writeText(sink, tag.getAsString());
                 break;
             case Tag.TAG_BYTE_ARRAY:
                 byte[] bytes = ((ByteArrayTag) tag).getAsByteArray();
@@ -85,7 +85,7 @@ final class CanonicalNbt {
                 Collections.sort(names);
                 writeInt(sink, names.size());
                 for (String name : names) {
-                    StableItemKey.writeText(sink, name);
+                    StableKey.writeText(sink, name);
                     writeTag(compound.get(name), sink, depth + 1);
                 }
                 break;

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/implementations/NativeItemIdentity.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/implementations/NativeItemIdentity.java
@@ -7,19 +7,19 @@ import org.jetbrains.annotations.NotNull;
 import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
-import pl.kuba6000.ae2webintegration.core.identity.StableItemKey;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 
 /** Exact native AE key identity, including persistent addon data supported by native codecs. */
 public final class NativeItemIdentity {
 
     private NativeItemIdentity() {}
 
-    public static @NotNull StableItemKey getStableKey(@NotNull AEKey key) {
+    public static @NotNull StableKey getStableKey(@NotNull AEKey key) {
         CompoundTag tag = key.toTagGeneric();
         // The native codec allocates its tag first. Bounds cover only the subsequent traversal.
-        return StableItemKey.create(sink -> {
-            StableItemKey.writeText(sink, kind(key));
-            StableItemKey.writeText(
+        return StableKey.create(sink -> {
+            StableKey.writeText(sink, kind(key));
+            StableKey.writeText(
                 sink,
                 key.getId()
                     .toString());

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/implementations/NativeItemIdentity.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/implementations/NativeItemIdentity.java
@@ -14,7 +14,7 @@ public final class NativeItemIdentity {
 
     private NativeItemIdentity() {}
 
-    public static @NotNull StableKey getStableKey(@NotNull AEKey key) {
+    public static @NotNull StableKey getKey(@NotNull AEKey key) {
         CompoundTag tag = key.toTagGeneric();
         // The native codec allocates its tag first. Bounds cover only the subsequent traversal.
         return StableKey.create(sink -> {

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -24,7 +24,7 @@ public class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     private @Nullable StableKey web$stableKey;
 
     @Override
-    public @NotNull String web$getId() {
+    public @NotNull StableKey web$getId() {
         if (web$stableKey == null) {
             CraftingCPUCluster cluster = (CraftingCPUCluster) (Object) this;
             var position = cluster.getBoundsMin();
@@ -41,7 +41,7 @@ public class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
                     .putInt(position.getZ());
             });
         }
-        return web$stableKey.toString();
+        return web$stableKey;
     }
 
     @Override

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -24,7 +24,7 @@ public class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
     private @Nullable StableKey web$stableKey;
 
     @Override
-    public @NotNull StableKey web$getId() {
+    public @NotNull StableKey web$getKey() {
         if (web$stableKey == null) {
             CraftingCPUCluster cluster = (CraftingCPUCluster) (Object) this;
             var position = cluster.getBoundsMin();

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -1,7 +1,9 @@
 package pl.kuba6000.ae2webintegration.ae2interface.mixins.AE2.implementations;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 
 import appeng.api.networking.crafting.ICraftingCPU;
 import appeng.api.stacks.AEKey;
@@ -9,6 +11,8 @@ import appeng.api.stacks.KeyCounter;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import pl.kuba6000.ae2webintegration.ae2interface.accessors.ICraftingCPULogicAccessor;
 import pl.kuba6000.ae2webintegration.ae2interface.implementations.AE;
+import pl.kuba6000.ae2webintegration.core.identity.CpuIdentity;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.ICraftingCPUCluster;
@@ -17,13 +21,24 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IStackList;
 @Mixin(value = CraftingCPUCluster.class, remap = false)
 public class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
 
+    @Unique
+    private @Nullable StableKey web$stableKey;
+
     @Override
     public @NotNull String web$getId() {
-        CraftingCPUCluster cluster = (CraftingCPUCluster) (Object) this;
-        var position = cluster.getBoundsMin();
-        return "ae2:" + cluster.getLevel()
-            .dimension()
-            .location() + ":" + position.getX() + ":" + position.getY() + ":" + position.getZ();
+        if (web$stableKey == null) {
+            CraftingCPUCluster cluster = (CraftingCPUCluster) (Object) this;
+            var position = cluster.getBoundsMin();
+            web$stableKey = CpuIdentity.ae2(
+                cluster.getLevel()
+                    .dimension()
+                    .location()
+                    .toString(),
+                position.getX(),
+                position.getY(),
+                position.getZ());
+        }
+        return web$stableKey.toString();
     }
 
     @Override

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -29,7 +29,6 @@ public class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
             CraftingCPUCluster cluster = (CraftingCPUCluster) (Object) this;
             var position = cluster.getBoundsMin();
             web$stableKey = StableKey.create(sink -> {
-                StableKey.writeText(sink, "cpu:ae2");
                 StableKey.writeText(
                     sink,
                     cluster.getLevel()

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -11,7 +11,6 @@ import appeng.api.stacks.KeyCounter;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import pl.kuba6000.ae2webintegration.ae2interface.accessors.ICraftingCPULogicAccessor;
 import pl.kuba6000.ae2webintegration.ae2interface.implementations.AE;
-import pl.kuba6000.ae2webintegration.core.identity.CpuIdentity;
 import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
@@ -29,14 +28,18 @@ public class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
         if (web$stableKey == null) {
             CraftingCPUCluster cluster = (CraftingCPUCluster) (Object) this;
             var position = cluster.getBoundsMin();
-            web$stableKey = CpuIdentity.ae2(
-                cluster.getLevel()
-                    .dimension()
-                    .location()
-                    .toString(),
-                position.getX(),
-                position.getY(),
-                position.getZ());
+            web$stableKey = StableKey.create(sink -> {
+                StableKey.writeText(sink, "cpu:ae2");
+                StableKey.writeText(
+                    sink,
+                    cluster.getLevel()
+                        .dimension()
+                        .location()
+                        .toString());
+                sink.putInt(position.getX())
+                    .putInt(position.getY())
+                    .putInt(position.getZ());
+            });
         }
         return web$stableKey.toString();
     }

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AECraftingCPUClusterMixin.java
@@ -1,5 +1,6 @@
 package pl.kuba6000.ae2webintegration.ae2interface.mixins.AE2.implementations;
 
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 
 import appeng.api.networking.crafting.ICraftingCPU;
@@ -15,6 +16,15 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IStackList;
 
 @Mixin(value = CraftingCPUCluster.class, remap = false)
 public class AECraftingCPUClusterMixin implements ICraftingCPUCluster {
+
+    @Override
+    public @NotNull String web$getId() {
+        CraftingCPUCluster cluster = (CraftingCPUCluster) (Object) this;
+        var position = cluster.getBoundsMin();
+        return "ae2:" + cluster.getLevel()
+            .dimension()
+            .location() + ":" + position.getX() + ":" + position.getY() + ":" + position.getZ();
+    }
 
     @Override
     public void web$setInternalID(int id) {

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEItemMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEItemMixin.java
@@ -1,7 +1,5 @@
 package pl.kuba6000.ae2webintegration.ae2interface.mixins.AE2.implementations;
 
-import java.io.IOException;
-
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 
@@ -20,12 +18,12 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 public abstract class AEItemMixin implements IAEKey {
 
     @Override
-    public @NotNull StableKey web$getStableKey() throws IOException {
-        return NativeItemIdentity.getStableKey((AEKey) (Object) this);
+    public @NotNull StableKey web$getKey() {
+        return NativeItemIdentity.getKey((AEKey) (Object) this);
     }
 
     @Override
-    public IAEKey web$copyIdentity() throws IOException {
+    public IAEKey web$copyIdentity() {
         return (IAEKey) NativeItemIdentity.copy((AEKey) (Object) this);
     }
 

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEItemMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/AE2/implementations/AEItemMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import appeng.api.stacks.AEKey;
 import appeng.me.Grid;
 import pl.kuba6000.ae2webintegration.ae2interface.implementations.NativeItemIdentity;
-import pl.kuba6000.ae2webintegration.core.identity.StableItemKey;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGrid;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 
@@ -20,7 +20,7 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 public abstract class AEItemMixin implements IAEKey {
 
     @Override
-    public @NotNull StableItemKey web$getStableKey() throws IOException {
+    public @NotNull StableKey web$getStableKey() throws IOException {
         return NativeItemIdentity.getStableKey((AEKey) (Object) this);
     }
 

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
@@ -10,12 +10,15 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
 import appeng.api.networking.crafting.ICraftingCPU;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;
 import pl.kuba6000.ae2webintegration.ae2interface.accessors.ICraftingCPULogicAccessor;
 import pl.kuba6000.ae2webintegration.ae2interface.implementations.AE;
+import pl.kuba6000.ae2webintegration.core.identity.CpuIdentity;
+import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.ICraftingCPUCluster;
@@ -33,15 +36,28 @@ public class AdvCraftingCPUMixin implements ICraftingCPUCluster {
     @Final
     private AdvCraftingCPUCluster cluster;
 
+    @Unique
+    private @Nullable StableKey web$stableKey;
+
     @Override
     public @NotNull String web$getId() {
-        if (uniqueId != null) return "advanced_ae:" + uniqueId;
-
-        // The free-capacity CPU has no UUID and is recreated as available storage changes.
-        var position = cluster.getBoundsMin();
-        return "advanced_ae:free:" + cluster.getLevel()
-            .dimension()
-            .location() + ":" + position.getX() + ":" + position.getY() + ":" + position.getZ();
+        if (web$stableKey == null) {
+            if (uniqueId != null) {
+                web$stableKey = CpuIdentity.advanced(uniqueId);
+            } else {
+                // The free-capacity CPU has no UUID and is recreated as available storage changes.
+                var position = cluster.getBoundsMin();
+                web$stableKey = CpuIdentity.advancedFree(
+                    cluster.getLevel()
+                        .dimension()
+                        .location()
+                        .toString(),
+                    position.getX(),
+                    position.getY(),
+                    position.getZ());
+            }
+        }
+        return web$stableKey.toString();
     }
 
     @Override

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
@@ -39,7 +39,7 @@ public class AdvCraftingCPUMixin implements ICraftingCPUCluster {
     private @Nullable StableKey web$stableKey;
 
     @Override
-    public @NotNull StableKey web$getId() {
+    public @NotNull StableKey web$getKey() {
         if (web$stableKey == null) {
             web$stableKey = StableKey.create(sink -> {
                 if (uniqueId != null) {

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
@@ -39,7 +39,7 @@ public class AdvCraftingCPUMixin implements ICraftingCPUCluster {
     private @Nullable StableKey web$stableKey;
 
     @Override
-    public @NotNull String web$getId() {
+    public @NotNull StableKey web$getId() {
         if (web$stableKey == null) {
             web$stableKey = StableKey.create(sink -> {
                 if (uniqueId != null) {
@@ -62,7 +62,7 @@ public class AdvCraftingCPUMixin implements ICraftingCPUCluster {
                 }
             });
         }
-        return web$stableKey.toString();
+        return web$stableKey;
     }
 
     @Override

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
@@ -17,7 +17,6 @@ import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;
 import pl.kuba6000.ae2webintegration.ae2interface.accessors.ICraftingCPULogicAccessor;
 import pl.kuba6000.ae2webintegration.ae2interface.implementations.AE;
-import pl.kuba6000.ae2webintegration.core.identity.CpuIdentity;
 import pl.kuba6000.ae2webintegration.core.identity.StableKey;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEGenericStack;
 import pl.kuba6000.ae2webintegration.core.interfaces.IAEKey;
@@ -42,20 +41,26 @@ public class AdvCraftingCPUMixin implements ICraftingCPUCluster {
     @Override
     public @NotNull String web$getId() {
         if (web$stableKey == null) {
-            if (uniqueId != null) {
-                web$stableKey = CpuIdentity.advanced(uniqueId);
-            } else {
-                // The free-capacity CPU has no UUID and is recreated as available storage changes.
-                var position = cluster.getBoundsMin();
-                web$stableKey = CpuIdentity.advancedFree(
-                    cluster.getLevel()
-                        .dimension()
-                        .location()
-                        .toString(),
-                    position.getX(),
-                    position.getY(),
-                    position.getZ());
-            }
+            web$stableKey = StableKey.create(sink -> {
+                if (uniqueId != null) {
+                    StableKey.writeText(sink, "cpu:advanced_ae");
+                    sink.putLong(uniqueId.getMostSignificantBits())
+                        .putLong(uniqueId.getLeastSignificantBits());
+                } else {
+                    // The free-capacity CPU has no UUID and is recreated as available storage changes.
+                    var position = cluster.getBoundsMin();
+                    StableKey.writeText(sink, "cpu:advanced_ae:free");
+                    StableKey.writeText(
+                        sink,
+                        cluster.getLevel()
+                            .dimension()
+                            .location()
+                            .toString());
+                    sink.putInt(position.getX())
+                        .putInt(position.getY())
+                        .putInt(position.getZ());
+                }
+            });
         }
         return web$stableKey.toString();
     }

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
@@ -43,13 +43,11 @@ public class AdvCraftingCPUMixin implements ICraftingCPUCluster {
         if (web$stableKey == null) {
             web$stableKey = StableKey.create(sink -> {
                 if (uniqueId != null) {
-                    StableKey.writeText(sink, "cpu:advanced_ae");
                     sink.putLong(uniqueId.getMostSignificantBits())
                         .putLong(uniqueId.getLeastSignificantBits());
                 } else {
                     // The free-capacity CPU has no UUID and is recreated as available storage changes.
                     var position = cluster.getBoundsMin();
-                    StableKey.writeText(sink, "cpu:advanced_ae:free");
                     StableKey.writeText(
                         sink,
                         cluster.getLevel()

--- a/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
+++ b/src/main/java/pl/kuba6000/ae2webintegration/ae2interface/mixins/advanced_ae/AdvCraftingCPUMixin.java
@@ -1,8 +1,15 @@
 package pl.kuba6000.ae2webintegration.ae2interface.mixins.advanced_ae;
 
-import net.pedroksl.advanced_ae.common.cluster.AdvCraftingCPU;
+import java.util.UUID;
 
+import net.pedroksl.advanced_ae.common.cluster.AdvCraftingCPU;
+import net.pedroksl.advanced_ae.common.cluster.AdvCraftingCPUCluster;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 
 import appeng.api.networking.crafting.ICraftingCPU;
 import appeng.api.stacks.AEKey;
@@ -16,6 +23,26 @@ import pl.kuba6000.ae2webintegration.core.interfaces.IStackList;
 
 @Mixin(value = AdvCraftingCPU.class, remap = false)
 public class AdvCraftingCPUMixin implements ICraftingCPUCluster {
+
+    @Shadow
+    @Final
+    @Nullable
+    private UUID uniqueId;
+
+    @Shadow
+    @Final
+    private AdvCraftingCPUCluster cluster;
+
+    @Override
+    public @NotNull String web$getId() {
+        if (uniqueId != null) return "advanced_ae:" + uniqueId;
+
+        // The free-capacity CPU has no UUID and is recreated as available storage changes.
+        var position = cluster.getBoundsMin();
+        return "advanced_ae:free:" + cluster.getLevel()
+            .dimension()
+            .location() + ":" + position.getX() + ":" + position.getY() + ":" + position.getZ();
+    }
 
     @Override
     public void web$setInternalID(int id) {


### PR DESCRIPTION
Implement the native CPU identity contract from #71 on Minecraft 1.20.1, allowing equally named CPUs to remain separate targets on the website.

The existing ordinary AE2 CPU mixin hashes the native dimension registry key and minimum X/Y/Z. AdvancedAE virtual CPUs hash their persisted UUID; the free-capacity entry hashes its physical cluster address. Each CPU retains its StableKey lazily. Identity inputs have no type prefixes, and all native decisions remain in adapters.

Use web$getKey() for both resources and CPUs, returning the shared StableKey. Remove checked IOException from native identity access/copy; item identity encoding is unchanged. Pin core to f8c515d37058eb8172b50a3ad440cd51572216f2.

Validation: full Gradle build and formatting passed. A local native GameTest passed with ordinary AE2, AdvancedAE virtual CPU reconstruction from a UUID, and free-capacity reconstruction. Generated UUID/free-capacity tokens match independent MurmurHash reference vectors. No full gameplay save/restart test was performed.

Depends on #71. After its squash merge, update the core pin to the resulting core commit before merging this PR.
